### PR TITLE
Alignment

### DIFF
--- a/src/backends/rust.rs
+++ b/src/backends/rust.rs
@@ -284,14 +284,13 @@ fn build_type(
         quote! { #[derive(#(#extra_derives),*)] }
     };
 
-    let packed = if *packed {
-        quote! { , packed }
+    // Packing and alignment are mutually exclusive
+    let (packed, alignment) = if *packed {
+        (quote! { , packed }, quote! {})
     } else {
-        quote! {}
+        let alignment: syn::Index = alignment.into();
+        (quote! {}, quote! { , align(#alignment) })
     };
-
-    let alignment: syn::Index = alignment.into();
-    let alignment = quote! { , align(#alignment) };
 
     Ok(quote! {
         #derives

--- a/src/backends/rust.rs
+++ b/src/backends/rust.rs
@@ -290,6 +290,7 @@ fn build_type(
         quote! {}
     };
 
+    let alignment: syn::Index = alignment.into();
     let alignment = quote! { , align(#alignment) };
 
     Ok(quote! {

--- a/src/backends/rust.rs
+++ b/src/backends/rust.rs
@@ -185,6 +185,7 @@ fn build_function(
 fn build_type(
     name: &ItemPathSegment,
     size: usize,
+    alignment: usize,
     visibility: types::Visibility,
     type_definition: &types::TypeDefinition,
 ) -> anyhow::Result<proc_macro2::TokenStream> {
@@ -289,9 +290,11 @@ fn build_type(
         quote! {}
     };
 
+    let alignment = quote! { , align(#alignment) };
+
     Ok(quote! {
         #derives
-        #[repr(C #packed)]
+        #[repr(C #packed #alignment)]
         #visibility struct #name_ident {
             #(#fields),*
         }
@@ -397,14 +400,19 @@ fn build_item(definition: &types::ItemDefinition) -> anyhow::Result<proc_macro2:
         .last()
         .context("failed to get last of item path")?;
 
-    let types::ItemStateResolved { size, inner } =
-        &definition.resolved().context("type was not resolved")?;
+    let types::ItemStateResolved {
+        size,
+        inner,
+        alignment,
+    } = &definition.resolved().context("type was not resolved")?;
 
     let visibility = definition.visibility;
 
     match definition.category() {
         ItemCategory::Defined => match inner {
-            types::ItemDefinitionInner::Type(td) => build_type(name, *size, visibility, td),
+            types::ItemDefinitionInner::Type(td) => {
+                build_type(name, *size, *alignment, visibility, td)
+            }
             types::ItemDefinitionInner::Enum(ed) => build_enum(name, *size, visibility, ed),
         },
         ItemCategory::Predefined => Ok(quote! {}),

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -219,6 +219,10 @@ impl Attribute {
         Self::integer_fn("size", size as isize)
     }
 
+    pub fn align(align: usize) -> Self {
+        Self::integer_fn("align", align as isize)
+    }
+
     pub fn singleton(address: usize) -> Self {
         Self::integer_fn("singleton", address as isize)
     }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -259,6 +259,10 @@ impl Attribute {
         Attribute::Ident("base".into())
     }
 
+    pub fn packed() -> Self {
+        Attribute::Ident("packed".into())
+    }
+
     // HACK_SKIP_VFTABLE: <https://github.com/philpax/pyxis/issues/13>
     pub fn hack_skip_vftable() -> Self {
         Attribute::Ident("hack_skip_vftable".into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ pub mod grammar;
 pub mod parser;
 pub mod semantic_analysis;
 
+pub(crate) mod util;
+
 pub fn build(in_dir: &Path, out_dir: &Path, pointer_size: usize) -> anyhow::Result<()> {
     let mut semantic_state = semantic_analysis::SemanticState::new(pointer_size);
 

--- a/src/semantic_analysis/semantic_state.rs
+++ b/src/semantic_analysis/semantic_state.rs
@@ -635,7 +635,7 @@ impl SemanticState {
                     let alignment = region.type_ref.alignment(&self.type_registry).unwrap();
                     if last_address % alignment != 0 {
                         anyhow::bail!(
-                            "field {name} (at 0x{last_address:X}) is not aligned to {alignment}"
+                            "field {name} (at 0x{last_address:X}) is not aligned to {alignment}, which is the alignment of its type"
                         );
                     }
                     last_address += region.size(&self.type_registry).unwrap();

--- a/src/semantic_analysis/tests.rs
+++ b/src/semantic_analysis/tests.rs
@@ -305,7 +305,7 @@ fn can_use_type_from_another_module() {
 fn will_fail_on_an_extern_without_size() {
     assert_ast_produces_failure(
         M::new().with_extern_types([("TestType".into(), vec![])]),
-        "failed to find size attribute for extern type",
+        "failed to find `size` attribute for extern type `TestType` in module `test`",
     );
 }
 
@@ -1050,7 +1050,7 @@ fn will_reject_defaultable_on_pointer() {
             )])
             .with_attributes([A::defaultable()]),
         )]),
-        "field field_1 of type test::TestType is not a defaultable type (pointer or function?)",
+        "field `field_1` of type `test::TestType` is not a defaultable type (pointer or function?)",
     );
 }
 
@@ -1070,7 +1070,7 @@ fn will_reject_defaultable_on_enum_field() {
                 ED::new(T::ident("u32"), [ES::field("Item1")], []),
             ),
         ]),
-        "field field_1 of type test::TestType is not a defaultable type",
+        "field `field_1` of type `test::TestType` is not a defaultable type",
     );
 }
 
@@ -1087,7 +1087,7 @@ fn can_handle_defaultable_on_enum_with_default_field() {
             )
             .with_attributes([A::defaultable()]),
         )]),
-        "enum test::TestType is marked as defaultable but has no default variant set",
+        "enum `test::TestType` is marked as defaultable but has no default variant set",
     );
 
     assert_ast_produces_failure(
@@ -1104,7 +1104,7 @@ fn can_handle_defaultable_on_enum_with_default_field() {
             )
             .with_attributes([]),
         )]),
-        "enum test::TestType has a default variant set but is not marked as defaultable",
+        "enum `test::TestType` has a default variant set but is not marked as defaultable",
     );
 
     assert_ast_produces_type_definitions(
@@ -1153,7 +1153,7 @@ fn will_reject_defaultable_on_non_defaultable_type() {
             ),
             ID::new(V::Public, "TestNonDefaultable", TD::new([])),
         ]),
-        "field field_1 of type test::TestType is not a defaultable type",
+        "field `field_1` of type `test::TestType` is not a defaultable type",
     );
 }
 
@@ -1172,7 +1172,7 @@ pub mod alignment {
                 ])
                 .with_attributes([A::align(4)]),
             )]),
-            "size 7 is not a multiple of alignment 4",
+            "the type `test::TestType` has a size of 7, which is not a multiple of its alignment 4",
         );
     }
 
@@ -1185,7 +1185,7 @@ pub mod alignment {
                 TD::new([TS::field(V::Public, "field_1", T::ident("i32"))
                     .with_attributes([A::address(1)])]),
             )]),
-            "field field_1 (at 0x1) is not aligned to 4, which is the alignment of its type",
+            "field `field_1` of type `test::TestType` is located at 0x1, which is not divisible by 4 (the alignment of the type of the field)",
         );
     }
 
@@ -1202,7 +1202,7 @@ pub mod alignment {
                 ])
                 .with_attributes([A::align(4)]),
             )]),
-            "alignment 4 is less than minimum required alignment 8",
+            "alignment 4 is less than minimum required alignment 8 for type `test::TestType`",
         );
     }
 
@@ -1215,7 +1215,7 @@ pub mod alignment {
                 TD::new([TS::field(V::Public, "field_1", T::ident("i32"))])
                     .with_attributes([A::align(4), A::packed()]),
             )]),
-            "cannot specify both packed and align attributes",
+            "cannot specify both `packed` and `align` attributes for type `test::TestType`",
         );
     }
 
@@ -1228,7 +1228,7 @@ pub mod alignment {
                 TD::new([TS::field(V::Public, "field_1", T::ident("bool"))
                     .with_attributes([A::address(0xEC4)])]),
             )]),
-            "size 3781 is not a multiple of alignment 4",
+            "the type `test::TestType` has a size of 3781, which is not a multiple of its alignment 4",
         );
 
         assert_ast_produces_type_definitions(

--- a/src/semantic_analysis/tests.rs
+++ b/src/semantic_analysis/tests.rs
@@ -59,13 +59,15 @@ fn can_resolve_basic_struct() {
                 TS::field(V::Public, "field_1", T::ident("i32")),
                 TS::field(V::Private, "_", T::unknown(4)),
                 TS::field(V::Public, "field_2", T::ident("u64")),
-            ]),
+            ])
+            .with_attributes([A::align(8)]),
         )]),
         [SID::defined_resolved(
             SV::Public,
             "test::TestType",
             SISR {
                 size: 16,
+                alignment: 8,
                 inner: STD::new()
                     .with_regions([
                         SR::field(SV::Public, "field_1", ST::raw("i32")),
@@ -92,10 +94,12 @@ fn can_resolve_pointer_to_another_struct() {
                 "TestType2",
                 TD::new([
                     TS::field(V::Public, "field_1", T::ident("i32")),
-                    TS::field(V::Public, "field_2", T::ident("TestType1")),
+                    TS::field(V::Public, "field_2", T::ident("TestType1"))
+                        .with_attributes([A::address(8)]),
                     TS::field(V::Public, "field_3", T::ident("TestType1").const_pointer()),
                     TS::field(V::Public, "field_4", T::ident("TestType1").mut_pointer()),
-                ]),
+                ])
+                .with_attributes([A::align(8)]),
             ),
         ]),
         [
@@ -104,6 +108,7 @@ fn can_resolve_pointer_to_another_struct() {
                 "test::TestType1",
                 SISR {
                     size: 8,
+                    alignment: 8,
                     inner: STD::new()
                         .with_regions([SR::field(SV::Public, "field_1", ST::raw("u64"))])
                         .into(),
@@ -113,10 +118,12 @@ fn can_resolve_pointer_to_another_struct() {
                 SV::Public,
                 "test::TestType2",
                 SISR {
-                    size: 20,
+                    size: 24,
+                    alignment: 8,
                     inner: STD::new()
                         .with_regions([
                             SR::field(SV::Public, "field_1", ST::raw("i32")),
+                            SR::field(SV::Private, "_field_4", unknown(4)),
                             SR::field(SV::Public, "field_2", ST::raw("test::TestType1")),
                             SR::field(
                                 SV::Public,
@@ -184,6 +191,7 @@ fn can_resolve_complex_type() {
                 "test::TestType",
                 SISR {
                     size: 8,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([
                             SR::field(SV::Public, "field_1", ST::raw("i32")),
@@ -197,6 +205,7 @@ fn can_resolve_complex_type() {
                 "test::Singleton",
                 SISR {
                     size: 0x1750,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([
                             SR::field(SV::Private, "_field_0", unknown(0x78)),
@@ -277,6 +286,7 @@ fn can_use_type_from_another_module() {
             path.clone(),
             SISR {
                 size: 4,
+                alignment: 4,
                 inner: STD::new()
                     .with_regions([SR::field(
                         SV::Private,
@@ -301,7 +311,7 @@ fn will_fail_on_an_extern_without_size() {
 fn can_resolve_embed_of_an_extern() {
     assert_ast_produces_type_definitions(
         M::new()
-            .with_extern_types([("TestType1".into(), vec![A::size(16)])])
+            .with_extern_types([("TestType1".into(), vec![A::size(16), A::align(4)])])
             .with_definitions([ID::new(
                 V::Public,
                 "TestType2",
@@ -318,6 +328,7 @@ fn can_resolve_embed_of_an_extern() {
                 "test::TestType2",
                 SISR {
                     size: 28,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([
                             SR::field(SV::Public, "field_1", ST::raw("i32")),
@@ -341,6 +352,7 @@ fn can_resolve_embed_of_an_extern() {
                 path: "test::TestType1".into(),
                 state: SISR {
                     size: 16,
+                    alignment: 4,
                     inner: STD::new().with_regions([]).into(),
                 }
                 .into(),
@@ -388,6 +400,7 @@ fn can_generate_vftable() {
                 "test::TestType",
                 SISR {
                     size: 4,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([SR::field(
                             SV::Public,
@@ -419,6 +432,7 @@ fn can_generate_vftable() {
                 "test::TestTypeVftable",
                 SISR {
                     size: 16,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([
                             SR::field(
@@ -497,6 +511,7 @@ fn can_generate_vftable_with_indices() {
                 "test::TestType",
                 SISR {
                     size: 4,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([SR::field(
                             SV::Public,
@@ -532,6 +547,7 @@ fn can_generate_vftable_with_indices() {
                 "test::TestTypeVftable",
                 SISR {
                     size: 32,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([
                             make_vfunc_region(0),
@@ -613,6 +629,7 @@ fn will_propagate_calling_convention_for_impl_and_vftable() {
                 "test::TestType",
                 SISR {
                     size: 4,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([SR::field(
                             SV::Public,
@@ -641,6 +658,7 @@ fn will_propagate_calling_convention_for_impl_and_vftable() {
                 "test::TestTypeVftable",
                 SISR {
                     size: 4,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([SR::field(
                             SV::Public,
@@ -694,6 +712,7 @@ fn can_generate_vftable_without_vftable() {
                 "test::TestType",
                 SISR {
                     size: 16,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([
                             SR::field(
@@ -721,6 +740,7 @@ fn can_generate_vftable_without_vftable() {
                 "test::TestTypeWithoutVftable",
                 SISR {
                     size: 12,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([
                             SR::field(SV::Private, "_field_0", unknown(4)),
@@ -736,6 +756,7 @@ fn can_generate_vftable_without_vftable() {
                 "test::TestTypeVftable",
                 SISR {
                     size: 4,
+                    alignment: 4,
                     inner: STD::new()
                         .with_regions([SR::field(
                             SV::Public,
@@ -824,6 +845,7 @@ fn can_resolve_enum() {
             "test::TestType",
             SISR {
                 size: 4,
+                alignment: 4,
                 inner: SED::new(ST::raw("u32"))
                     .with_fields([
                         ("Item0", -2),
@@ -896,6 +918,7 @@ fn can_extract_copyable_and_cloneable_correctly() {
             "test::TestType",
             SISR {
                 size: 4,
+                alignment: 4,
                 inner: STD::new()
                     .with_regions([SR::field(SV::Private, "field_1", ST::raw("i32"))])
                     .with_cloneable(true)
@@ -917,6 +940,7 @@ fn can_extract_copyable_and_cloneable_correctly() {
             "test::TestType",
             SISR {
                 size: 4,
+                alignment: 4,
                 inner: STD::new()
                     .with_regions([SR::field(SV::Private, "field_1", ST::raw("i32"))])
                     .with_copyable(true)
@@ -945,6 +969,7 @@ fn can_extract_copyable_and_cloneable_for_enum_correctly() {
             "test::TestType",
             SISR {
                 size: 4,
+                alignment: 4,
                 inner: SED::new(ST::raw("u32"))
                     .with_fields([("Item1", 0), ("Item2", 1)])
                     .with_cloneable(true)
@@ -969,6 +994,7 @@ fn can_extract_copyable_and_cloneable_for_enum_correctly() {
             "test::TestType",
             SISR {
                 size: 4,
+                alignment: 4,
                 inner: SED::new(ST::raw("u32"))
                     .with_fields([("Item1", 0), ("Item2", 1)])
                     .with_copyable(true)
@@ -996,6 +1022,7 @@ fn can_handle_defaultable_on_primitive_types() {
             "test::TestType",
             SISR {
                 size: 68,
+                alignment: 4,
                 inner: STD::new()
                     .with_regions([
                         SR::field(SV::Private, "field_1", ST::raw("i32")),
@@ -1097,6 +1124,7 @@ fn can_handle_defaultable_on_enum_with_default_field() {
             "test::TestType",
             SISR {
                 size: 4,
+                alignment: 4,
                 inner: SED::new(ST::raw("u32"))
                     .with_fields([("Item1", 0), ("Item2", 1)])
                     .with_defaultable(true)
@@ -1237,6 +1265,7 @@ pub mod inheritance {
 
         pub struct InheritanceType {
             name: String,
+            alignment: usize,
             fields: Vec<(String, IPT, Vec<A>)>,
             vftable: Option<IV>,
         }
@@ -1244,10 +1273,12 @@ pub mod inheritance {
         impl IT {
             pub fn new(
                 name: impl Into<String>,
+                alignment: usize,
                 fields: impl IntoIterator<Item = (String, IPT, Vec<A>)>,
             ) -> Self {
                 Self {
                     name: name.into(),
+                    alignment,
                     fields: fields.into_iter().collect(),
                     vftable: None,
                 }
@@ -1292,7 +1323,8 @@ pub mod inheritance {
                             }),
                         )
                         .collect::<Vec<_>>(),
-                    ),
+                    )
+                    .with_attributes([A::align(self.alignment)]),
                 )
             }
 
@@ -1343,6 +1375,7 @@ pub mod inheritance {
                     format!("test::{}", self.name).as_str(),
                     SISR {
                         size,
+                        alignment: 4,
                         inner: type_definition.into(),
                     },
                 )
@@ -1375,6 +1408,7 @@ pub mod inheritance {
                     format!("test::{}", self.name_vftable).as_str(),
                     SISR {
                         size: self.functions.len() * 4,
+                        alignment: 4,
                         inner: STD::new()
                             .with_regions(
                                 self.functions
@@ -1491,6 +1525,7 @@ pub mod inheritance {
         fn b0_d0() {
             let base = IT::new(
                 "Base",
+                8,
                 [
                     ("field_1".to_string(), IPT::I32, vec![]),
                     ("_field_4".to_string(), IPT::Unknown(4), vec![]),
@@ -1500,6 +1535,7 @@ pub mod inheritance {
 
             let derived = IT::new(
                 "Derived",
+                8,
                 [(
                     "base".to_string(),
                     IPT::Named("Base".to_string(), 16),
@@ -1517,6 +1553,7 @@ pub mod inheritance {
         fn b0_d1() {
             let base = IT::new(
                 "Base",
+                8,
                 [
                     ("field_1".to_string(), IPT::I32, vec![]),
                     ("_field_4".to_string(), IPT::Unknown(4), vec![]),
@@ -1527,6 +1564,7 @@ pub mod inheritance {
             let derived_vftable = IV::new("Derived", "DerivedVftable", [vfunc("derived_vfunc")]);
             let derived = IT::new(
                 "Derived",
+                8,
                 [(
                     "base".to_string(),
                     IPT::Named("Base".to_string(), 16),
@@ -1578,6 +1616,7 @@ pub mod inheritance {
         fn a0_b0_d0() {
             let base_a = IT::new(
                 "BaseA",
+                8,
                 [
                     ("field_1".to_string(), IPT::I32, vec![]),
                     ("_field_4".to_string(), IPT::Unknown(4), vec![]),
@@ -1587,6 +1626,7 @@ pub mod inheritance {
 
             let base_b = IT::new(
                 "BaseB",
+                8,
                 [
                     ("field_1".to_string(), IPT::U64, vec![]),
                     ("_field_8".to_string(), IPT::Unknown(4), vec![]),
@@ -1596,6 +1636,7 @@ pub mod inheritance {
 
             let derived = IT::new(
                 "Derived",
+                8,
                 [
                     (
                         "base_a".to_string(),
@@ -1628,6 +1669,7 @@ pub mod inheritance {
         fn a0_b0_d1() {
             let base_a = IT::new(
                 "BaseA",
+                8,
                 [
                     ("field_1".to_string(), IPT::I32, vec![]),
                     ("_field_4".to_string(), IPT::Unknown(4), vec![]),
@@ -1637,6 +1679,7 @@ pub mod inheritance {
 
             let base_b = IT::new(
                 "BaseB",
+                8,
                 [
                     ("field_1".to_string(), IPT::U64, vec![]),
                     ("_field_8".to_string(), IPT::Unknown(4), vec![]),
@@ -1647,6 +1690,7 @@ pub mod inheritance {
             let derived_vftable = IV::new("Derived", "DerivedVftable", [derived_vfunc()]);
             let derived = IT::new(
                 "Derived",
+                8,
                 [
                     (
                         "base_a".to_string(),

--- a/src/semantic_analysis/type_registry.rs
+++ b/src/semantic_analysis/type_registry.rs
@@ -7,8 +7,8 @@ use crate::{
 
 #[derive(Debug)]
 pub struct TypeRegistry {
-    pub(crate) types: HashMap<ItemPath, ItemDefinition>,
-    pub(crate) pointer_size: usize,
+    types: HashMap<ItemPath, ItemDefinition>,
+    pointer_size: usize,
 }
 
 impl TypeRegistry {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,12 @@
+pub fn lcm(iter: impl Iterator<Item = usize>) -> usize {
+    iter.fold(1, |acc, x| acc * x / gcd(acc, x))
+}
+
+pub fn gcd(mut a: usize, mut b: usize) -> usize {
+    while b != 0 {
+        let temp = b;
+        b = a % b;
+        a = temp;
+    }
+    a
+}


### PR DESCRIPTION
Closes #24.
Closes #15.

TODO:

- [x] Fix the inheritance tests. The existence of a vftable complicates the alignment of the fields in the derived types; I may have to manually specify the addresses or rethink my DSL for this.
- [x] Write tests for each potential failure case:
  - Types whose size is not a multiple of their alignment should be rejected
  - Types with fields that don't match their corresponding types' alignment should be rejected
  - Types with a specified alignment lower than the LCM of the alignments of the fields, ~~or where the LCM does not divide the specified alignment~~, should be rejected
  - Types with both `packed` and `align` should be rejected
  - A test for #15 should be added.
- [x] Improve errors a tiny bit. Probably won't go all the way to #6, but it should at least always be obvious what type an error belongs to. (This isn't the case right now because adding `context` with the types will break the tests - I need a structured way to get the inner error)