### PR TITLE
Implement `min_size` attribute

### DIFF
--- a/codegen_tests/input/min_size.pyxis
+++ b/codegen_tests/input/min_size.pyxis
@@ -1,0 +1,12 @@
+/// Test type with min_size attribute
+#[min_size(32), align(16)]
+pub type TestType {
+    pub field_1: i32,
+    pub field_2: i32,
+}
+
+/// Another type to test min_size rounding
+#[min_size(24), align(16)]
+pub type RoundedType {
+    pub value: u64,
+}

--- a/codegen_tests/output/lib.rs
+++ b/codegen_tests/output/lib.rs
@@ -3,6 +3,7 @@ pub mod diamond_inheritance;
 pub mod doc_comments;
 pub mod enums;
 pub mod freestanding_functions;
+pub mod min_size;
 pub mod multiple_levels;
 pub mod singleton;
 pub mod two_base_classes;

--- a/codegen_tests/output/min_size.rs
+++ b/codegen_tests/output/min_size.rs
@@ -1,0 +1,54 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    clippy::missing_safety_doc,
+    clippy::unnecessary_cast
+)]
+#![cfg_attr(any(), rustfmt::skip)]
+#[repr(C, align(16))]
+/// Another type to test min_size rounding
+pub struct RoundedType {
+    pub value: u64,
+    _field_8: [u8; 24],
+}
+fn _RoundedType_size_check() {
+    unsafe {
+        ::std::mem::transmute::<[u8; 0x20], RoundedType>([0u8; 0x20]);
+    }
+    unreachable!()
+}
+impl RoundedType {}
+impl std::convert::AsRef<RoundedType> for RoundedType {
+    fn as_ref(&self) -> &RoundedType {
+        self
+    }
+}
+impl std::convert::AsMut<RoundedType> for RoundedType {
+    fn as_mut(&mut self) -> &mut RoundedType {
+        self
+    }
+}
+#[repr(C, align(16))]
+/// Test type with min_size attribute
+pub struct TestType {
+    pub field_1: i32,
+    pub field_2: i32,
+    _field_8: [u8; 24],
+}
+fn _TestType_size_check() {
+    unsafe {
+        ::std::mem::transmute::<[u8; 0x20], TestType>([0u8; 0x20]);
+    }
+    unreachable!()
+}
+impl TestType {}
+impl std::convert::AsRef<TestType> for TestType {
+    fn as_ref(&self) -> &TestType {
+        self
+    }
+}
+impl std::convert::AsMut<TestType> for TestType {
+    fn as_mut(&mut self) -> &mut TestType {
+        self
+    }
+}

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -248,6 +248,9 @@ impl Attribute {
     pub fn size(size: usize) -> Self {
         Self::integer_fn("size", size as isize)
     }
+    pub fn min_size(min_size: usize) -> Self {
+        Self::integer_fn("min_size", min_size as isize)
+    }
     pub fn align(align: usize) -> Self {
         Self::integer_fn("align", align as isize)
     }

--- a/src/semantic/tests/min_size.rs
+++ b/src/semantic/tests/min_size.rs
@@ -1,0 +1,158 @@
+use super::*;
+
+#[test]
+fn min_size_pads_to_minimum() {
+    // A type with natural size 4, min_size 16, should be padded to 16
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "TestType"),
+            TD::new([TS::field((V::Public, "field_1"), T::ident("i32"))])
+                .with_attributes([A::min_size(16)]),
+        )]),
+        [SID::defined_resolved(
+            (SV::Public, "test::TestType"),
+            SISR::new(
+                (16, pointer_size()),
+                STD::new().with_regions([
+                    SR::field((SV::Public, "field_1"), ST::raw("i32")),
+                    SR::field((SV::Private, "_field_4"), unknown(12)),
+                ]),
+            ),
+        )],
+    );
+}
+
+#[test]
+fn min_size_rounds_up_to_alignment() {
+    // A type with alignment 16 and min_size 24 should be rounded up to 32
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "TestType"),
+            TD::new([TS::field((V::Public, "field_1"), T::ident("i32"))])
+                .with_attributes([A::min_size(24), A::align(16)]),
+        )]),
+        [SID::defined_resolved(
+            (SV::Public, "test::TestType"),
+            SISR::new(
+                (32, 16),
+                STD::new().with_regions([
+                    SR::field((SV::Public, "field_1"), ST::raw("i32")),
+                    SR::field((SV::Private, "_field_4"), unknown(28)),
+                ]),
+            ),
+        )],
+    );
+}
+
+#[test]
+fn min_size_allows_natural_size_larger_than_minimum() {
+    // A type with natural size 16 and min_size 8 should remain size 16
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "TestType"),
+            TD::new([
+                TS::field((V::Public, "field_1"), T::ident("u64")),
+                TS::field((V::Public, "field_2"), T::ident("u64")),
+            ])
+            .with_attributes([A::min_size(8), A::align(8)]),
+        )]),
+        [SID::defined_resolved(
+            (SV::Public, "test::TestType"),
+            SISR::new(
+                (16, 8),
+                STD::new().with_regions([
+                    SR::field((SV::Public, "field_1"), ST::raw("u64")),
+                    SR::field((SV::Public, "field_2"), ST::raw("u64")),
+                ]),
+            ),
+        )],
+    );
+}
+
+#[test]
+fn min_size_with_explicit_address() {
+    // min_size should work with explicit field addresses
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "TestType"),
+            TD::new([
+                TS::field((V::Public, "field_1"), T::ident("i32")),
+                TS::field((V::Public, "field_2"), T::ident("i32"))
+                    .with_attributes([A::address(8)]),
+            ])
+            .with_attributes([A::min_size(32)]),
+        )]),
+        [SID::defined_resolved(
+            (SV::Public, "test::TestType"),
+            SISR::new(
+                (32, pointer_size()),
+                STD::new().with_regions([
+                    SR::field((SV::Public, "field_1"), ST::raw("i32")),
+                    SR::field((SV::Private, "_field_4"), unknown(4)),
+                    SR::field((SV::Public, "field_2"), ST::raw("i32")),
+                    SR::field((SV::Private, "_field_c"), unknown(20)),
+                ]),
+            ),
+        )],
+    );
+}
+
+#[test]
+fn both_size_and_min_size_should_be_rejected() {
+    assert_ast_produces_failure(
+        M::new().with_definitions([ID::new(
+            (V::Public, "TestType"),
+            TD::new([TS::field((V::Public, "field_1"), T::ident("i32"))])
+                .with_attributes([A::size(16), A::min_size(16)]),
+        )]),
+        "cannot specify both `size` and `min_size` attributes for type `test::TestType`",
+    );
+}
+
+#[test]
+fn min_size_equal_to_natural_size() {
+    // min_size equal to natural size should work fine
+    // Note: alignment is 4 (from i32) since there's only one field
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "TestType"),
+            TD::new([TS::field((V::Public, "field_1"), T::ident("i32"))])
+                .with_attributes([A::min_size(4)]),
+        )]),
+        [SID::defined_resolved(
+            (SV::Public, "test::TestType"),
+            SISR::new(
+                (4, 4),
+                STD::new().with_regions([SR::field((SV::Public, "field_1"), ST::raw("i32"))]),
+            ),
+        )],
+    );
+}
+
+#[test]
+fn min_size_with_packed() {
+    // min_size with packed should use alignment 1
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "TestType"),
+            TD::new([
+                TS::field((V::Public, "field_1"), T::ident("i32")),
+                TS::field((V::Public, "field_2"), T::ident("bool")),
+            ])
+            .with_attributes([A::packed(), A::min_size(10)]),
+        )]),
+        [SID::defined_resolved(
+            (SV::Public, "test::TestType"),
+            SISR::new(
+                (10, 1),
+                STD::new()
+                    .with_regions([
+                        SR::field((SV::Public, "field_1"), ST::raw("i32")),
+                        SR::field((SV::Public, "field_2"), ST::raw("bool")),
+                        SR::field((SV::Private, "_field_5"), unknown(5)),
+                    ])
+                    .with_packed(true),
+            ),
+        )],
+    );
+}

--- a/src/semantic/tests/mod.rs
+++ b/src/semantic/tests/mod.rs
@@ -8,6 +8,7 @@ use pretty_assertions::assert_eq;
 
 mod alignment;
 mod inheritance;
+mod min_size;
 mod util;
 use util::*;
 


### PR DESCRIPTION
Fixes issue #33 by adding a new `min_size` attribute that enforces a minimum size for types while automatically rounding up to the nearest alignment boundary.

Key changes:
- Added `min_size` helper method to Attribute enum in grammar.rs
- Implemented semantic validation in type_definition/mod.rs that:
  - Pre-calculates alignment based on field types
  - Rounds min_size up to nearest multiple of alignment
  - Ensures mutual exclusivity with `size` attribute
  - Allows natural size to exceed minimum size
- Added comprehensive semantic tests covering:
  - Basic padding to minimum size
  - Automatic rounding to alignment boundaries
  - Interaction with explicit alignment attributes
  - Interaction with packed attribute
  - Error handling for conflicting attributes
- Added codegen test demonstrating real-world usage

The implementation ensures that types with specific size requirements but challenging alignments (e.g., size 24 with alignment 16) are automatically rounded up to valid sizes (32 in this example).