### PR TITLE
Build JSON backend API

### DIFF
--- a/src/backends/json.ts
+++ b/src/backends/json.ts
@@ -2,6 +2,19 @@
 
 export type JsonArgument = { type: "const_self" } | { type: "mut_self" } | { type: "field"; name: string; type_ref: JsonType };
 
+/**
+ * Backend configuration with prologue and epilogue
+ */
+export type JsonBackend = { 
+/**
+ * Prologue code inserted at the beginning of generated output
+ */
+prologue: string | null; 
+/**
+ * Epilogue code inserted at the end of generated output
+ */
+epilogue: string | null };
+
 export type JsonBitflag = { 
 /**
  * Flag name
@@ -217,7 +230,11 @@ extern_values: JsonExternValue[];
 /**
  * Freestanding functions
  */
-functions: JsonFunction[] };
+functions: JsonFunction[]; 
+/**
+ * Backend configurations (prologue/epilogue for code generation)
+ */
+backends: { [key in string]: JsonBackend[] } };
 
 export type JsonRegion = { 
 /**


### PR DESCRIPTION
Add backend configurations (prologue/epilogue) to the JSON export so they can be documented appropriately. This allows documentation tools to understand and display the code generation context for different backends.

Changes:
- Add JsonBackend struct with prologue and epilogue fields
- Add backends field to JsonModule to store backend configurations
- Populate backends from semantic module data
- Update TypeScript type definitions