### PR TITLE
Fix formatter and add tests

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -907,22 +907,44 @@ impl FunctionBlock {
 pub struct Backend {
     pub name: Ident,
     pub prologue: Option<String>,
+    pub prologue_format: StringFormat,
     pub epilogue: Option<String>,
+    pub epilogue_format: StringFormat,
 }
 impl Backend {
     pub fn new(name: &str) -> Self {
         Self {
             name: name.into(),
             prologue: None,
+            prologue_format: StringFormat::Regular,
             epilogue: None,
+            epilogue_format: StringFormat::Regular,
         }
     }
     pub fn with_prologue(mut self, prologue: impl Into<String>) -> Self {
         self.prologue = Some(prologue.into());
         self
     }
+    pub fn with_prologue_format(
+        mut self,
+        prologue: impl Into<String>,
+        format: StringFormat,
+    ) -> Self {
+        self.prologue = Some(prologue.into());
+        self.prologue_format = format;
+        self
+    }
     pub fn with_epilogue(mut self, epilogue: impl Into<String>) -> Self {
         self.epilogue = Some(epilogue.into());
+        self
+    }
+    pub fn with_epilogue_format(
+        mut self,
+        epilogue: impl Into<String>,
+        format: StringFormat,
+    ) -> Self {
+        self.epilogue = Some(epilogue.into());
+        self.epilogue_format = format;
         self
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -721,11 +721,53 @@ impl Parser {
                     }),
                 }
             }
-            TokenKind::DocOuter(_)
-            | TokenKind::Pub
-            | TokenKind::Type
-            | TokenKind::Enum
-            | TokenKind::Bitflags => self.parse_item_definition().map(ModuleItem::Definition),
+            TokenKind::DocOuter(_) => {
+                // Peek ahead to see what comes after doc comments
+                let mut pos = self.pos;
+                while matches!(
+                    self.tokens.get(pos).map(|t| &t.kind),
+                    Some(TokenKind::DocOuter(_))
+                ) {
+                    pos += 1;
+                }
+
+                // Check if this is an extern type
+                if matches!(self.tokens.get(pos).map(|t| &t.kind), Some(TokenKind::Hash)) {
+                    // Skip attributes
+                    while matches!(self.tokens[pos].kind, TokenKind::Hash) {
+                        pos += 1; // skip #
+                        if matches!(self.tokens[pos].kind, TokenKind::LBracket) {
+                            pos += 1; // skip [
+                            // Skip until ]
+                            let mut depth = 1;
+                            while depth > 0 && pos < self.tokens.len() {
+                                match &self.tokens[pos].kind {
+                                    TokenKind::LBracket => depth += 1,
+                                    TokenKind::RBracket => depth -= 1,
+                                    _ => {}
+                                }
+                                pos += 1;
+                            }
+                        }
+                    }
+                }
+
+                // Now check what comes after doc comments (and possibly attributes)
+                if matches!(
+                    self.tokens.get(pos).map(|t| &t.kind),
+                    Some(TokenKind::Extern)
+                ) && matches!(
+                    self.tokens.get(pos + 1).map(|t| &t.kind),
+                    Some(TokenKind::Type)
+                ) {
+                    self.parse_extern_type()
+                } else {
+                    self.parse_item_definition().map(ModuleItem::Definition)
+                }
+            }
+            TokenKind::Pub | TokenKind::Type | TokenKind::Enum | TokenKind::Bitflags => {
+                self.parse_item_definition().map(ModuleItem::Definition)
+            }
             TokenKind::Impl => self.parse_impl_block().map(ModuleItem::Impl),
             TokenKind::Fn => {
                 // Freestanding function with attributes
@@ -851,7 +893,9 @@ impl Parser {
         let (name, _) = self.expect_ident()?;
 
         let mut prologue = None;
+        let mut prologue_format = StringFormat::Regular;
         let mut epilogue = None;
+        let mut epilogue_format = StringFormat::Regular;
 
         // Check if we have braces or direct prologue/epilogue
         if matches!(self.peek(), TokenKind::LBrace) {
@@ -862,15 +906,35 @@ impl Parser {
                 match self.peek() {
                     TokenKind::Prologue => {
                         self.advance();
-                        let string = self.parse_string_literal()?;
+                        let expr = self.parse_expr()?;
+                        if let Expr::StringLiteral { value, format } = expr {
+                            prologue = Some(value);
+                            prologue_format = format;
+                        } else {
+                            return Err(ParseError::ExpectedStringLiteral {
+                                found: self.peek().clone(),
+                                location: self.current().span.start,
+                                filename: self.filename.clone().into(),
+                                source: self.source.clone().into(),
+                            });
+                        }
                         self.expect(TokenKind::Semi)?;
-                        prologue = Some(string);
                     }
                     TokenKind::Epilogue => {
                         self.advance();
-                        let string = self.parse_string_literal()?;
+                        let expr = self.parse_expr()?;
+                        if let Expr::StringLiteral { value, format } = expr {
+                            epilogue = Some(value);
+                            epilogue_format = format;
+                        } else {
+                            return Err(ParseError::ExpectedStringLiteral {
+                                found: self.peek().clone(),
+                                location: self.current().span.start,
+                                filename: self.filename.clone().into(),
+                                source: self.source.clone().into(),
+                            });
+                        }
                         self.expect(TokenKind::Semi)?;
-                        epilogue = Some(string);
                     }
                     _ => {
                         return Err(ParseError::ExpectedPrologueOrEpilogue {
@@ -889,15 +953,35 @@ impl Parser {
             match self.peek() {
                 TokenKind::Prologue => {
                     self.advance();
-                    let string = self.parse_string_literal()?;
+                    let expr = self.parse_expr()?;
+                    if let Expr::StringLiteral { value, format } = expr {
+                        prologue = Some(value);
+                        prologue_format = format;
+                    } else {
+                        return Err(ParseError::ExpectedStringLiteral {
+                            found: self.peek().clone(),
+                            location: self.current().span.start,
+                            filename: self.filename.clone().into(),
+                            source: self.source.clone().into(),
+                        });
+                    }
                     self.expect(TokenKind::Semi)?;
-                    prologue = Some(string);
                 }
                 TokenKind::Epilogue => {
                     self.advance();
-                    let string = self.parse_string_literal()?;
+                    let expr = self.parse_expr()?;
+                    if let Expr::StringLiteral { value, format } = expr {
+                        epilogue = Some(value);
+                        epilogue_format = format;
+                    } else {
+                        return Err(ParseError::ExpectedStringLiteral {
+                            found: self.peek().clone(),
+                            location: self.current().span.start,
+                            filename: self.filename.clone().into(),
+                            source: self.source.clone().into(),
+                        });
+                    }
                     self.expect(TokenKind::Semi)?;
-                    epilogue = Some(string);
                 }
                 _ => {
                     return Err(ParseError::ExpectedBackendContent {
@@ -913,7 +997,9 @@ impl Parser {
         Ok(Backend {
             name,
             prologue,
+            prologue_format,
             epilogue,
+            epilogue_format,
         })
     }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,6 +1,7 @@
 use crate::{
     grammar::{
-        AttributeItem, IntFormat, ItemDefinitionInner, ModuleItem, TypeDefItem, Visibility,
+        AttributeItem, IntFormat, ItemDefinitionInner, ModuleItem, StringFormat, TypeDefItem,
+        Visibility,
         test_aliases::{int_literal, int_literal_with_format, *},
     },
     parser::{ParseError, parse_str, strip_spans::StripSpans},
@@ -445,31 +446,35 @@ backend rust epilogue r#"
 
     let ast = M::new().with_backends([
         B::new("rust")
-            .with_prologue(
+            .with_prologue_format(
                 r#"
         use std::ffi::CString;
         use std::os::raw::c_char;
     "#,
+                StringFormat::Raw,
             )
-            .with_epilogue(
+            .with_epilogue_format(
                 r#"
         fn main() {
             println!("Hello, world!");
         }
     "#,
+                StringFormat::Raw,
             ),
-        B::new("rust").with_prologue(
+        B::new("rust").with_prologue_format(
             r#"
     use std::ffi::CString;
     use std::os::raw::c_char;
 "#,
+            StringFormat::Raw,
         ),
-        B::new("rust").with_epilogue(
+        B::new("rust").with_epilogue_format(
             r#"
     fn main() {
         println!("Hello, world!");
     }
 "#,
+            StringFormat::Raw,
         ),
     ]);
 


### PR DESCRIPTION
This commit fixes three formatter issues:

1. String format preservation: Regular strings are no longer converted to raw strings automatically. The formatter now respects the StringFormat from the AST (Raw vs Regular). Backend prologue/epilogue strings maintain their original format.

2. Doc comment preservation: Both module-level doc comments (//!) and doc comments on extern type declarations are now properly printed. Updated the parser to recognize doc comments before extern types.

3. Binary literal formatting: Binary literals are now padded to the underlying type's width (u8->8 bits, u32->32 bits, etc.) with underscores inserted every 4 bits for readability. Example: 1 for u8 becomes 0b0000_0001

Changes include:
- Added prologue_format and epilogue_format fields to Backend struct
- Updated parser to capture and preserve string formats
- Updated pretty printer to use format information from AST
- Added binary literal padding and formatting logic
- Added module doc comment printing in print_module
- Added extern type doc comment printing in print_module_item
- Added parser lookahead for doc comments before extern types
- Added comprehensive tests for all three fixes