### PR TITLE
Remove bitflags dependency from Rust backend output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,12 +68,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-
-[[package]]
 name = "clap"
 version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,9 +110,6 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 [[package]]
 name = "codegen_tests"
 version = "0.1.0"
-dependencies = [
- "bitflags",
-]
 
 [[package]]
 name = "colorchoice"

--- a/codegen_tests/output/rust/Cargo.toml
+++ b/codegen_tests/output/rust/Cargo.toml
@@ -6,6 +6,3 @@ edition = "2024"
 [lib]
 name = "codegen_tests"
 path = "lib.rs"
-
-[dependencies]
-bitflags = "2.6"

--- a/codegen_tests/output/rust/bitflags.rs
+++ b/codegen_tests/output/rust/bitflags.rs
@@ -1,8 +1,7 @@
 #![cfg_attr(any(), rustfmt::skip)]
-bitflags::bitflags! {
-    #[derive(PartialEq, Eq, PartialOrd, Ord, Debug,)] pub struct TestBitflags : u32 {
-    const NONE = 0usize as _; const FLAG_1 = 1usize as _; const FLAG_2 = 2usize as _;
-    const FLAG_3 = 4usize as _; }
+crate::__bitflags! {
+    pub struct TestBitflags : u32 { const NONE = 0usize as _; const FLAG_1 = 1usize as _;
+    const FLAG_2 = 2usize as _; const FLAG_3 = 4usize as _; }
 }
 fn _TestBitflags_size_check() {
     unsafe {
@@ -10,10 +9,9 @@ fn _TestBitflags_size_check() {
     }
     unreachable!()
 }
-bitflags::bitflags! {
-    #[derive(PartialEq, Eq, PartialOrd, Ord, Debug,)] pub struct TestBitflags2 : u32 {
-    const NONE = 0usize as _; const FLAG_1 = 1usize as _; const FLAG_2 = 2usize as _;
-    const FLAG_3 = 4usize as _; }
+crate::__bitflags! {
+    pub struct TestBitflags2 : u32 { const NONE = 0usize as _; const FLAG_1 = 1usize as
+    _; const FLAG_2 = 2usize as _; const FLAG_3 = 4usize as _; }
 }
 fn _TestBitflags2_size_check() {
     unsafe {

--- a/codegen_tests/output/rust/lib.rs
+++ b/codegen_tests/output/rust/lib.rs
@@ -8,6 +8,94 @@
     clippy::module_inception
 )]
 #![cfg_attr(any(), rustfmt::skip)]
+#[macro_export]
+macro_rules! __bitflags {
+    (
+        $(#[$outer:meta])* $vis:vis struct $Name:ident : $T:ty { $($(#[$inner:meta])*
+        const $Flag:ident = $value:expr;)* }
+    ) => {
+        $(#[$outer])* #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[repr(transparent)] $vis struct $Name { bits : $T, } #[allow(dead_code)] impl
+        $Name { $($(#[$inner])* $vis const $Flag : Self = Self { bits : $value };)* #[doc
+        = " Returns an empty set of flags."] #[inline] pub const fn empty() -> Self {
+        Self { bits : 0 } } #[doc = " Returns the set containing all flags."] pub const
+        fn all() -> Self { Self { bits : 0 $(| Self::$Flag .bits)* } } #[doc =
+        " Returns the raw value of the flags currently stored."] #[inline] pub const fn
+        bits(& self) -> $T { self.bits } #[doc =
+        " Convert from underlying bit representation, unless that"] #[doc =
+        " representation contains bits that do not correspond to a flag."] #[inline] pub
+        const fn from_bits(bits : $T) -> ::core::option::Option < Self > { let truncated
+        = bits & Self::all().bits; if truncated == bits {
+        ::core::option::Option::Some(Self { bits }) } else { ::core::option::Option::None
+        } } #[doc = " Convert from underlying bit representation, dropping any bits"]
+        #[doc = " that do not correspond to flags."] #[inline] pub const fn
+        from_bits_truncate(bits : $T) -> Self { Self { bits : bits & Self::all().bits } }
+        #[doc = " Convert from underlying bit representation as is, without"] #[doc =
+        " checking whether any bits that do not correspond to a flag are"] #[doc =
+        " set."] #[inline] pub const fn from_bits_retain(bits : $T) -> Self { Self { bits
+        } } #[doc = " Returns `true` if no flags are currently stored."] #[inline] pub
+        const fn is_empty(& self) -> bool { self.bits == 0 } #[doc =
+        " Returns `true` if all flags are currently set."] #[inline] pub const fn
+        is_all(& self) -> bool { Self::all().bits | self.bits == self.bits } #[doc =
+        " Returns `true` if there are flags common to both `self` and"] #[doc =
+        " `other`."] #[inline] pub const fn intersects(& self, other : Self) -> bool {
+        self.bits & other.bits != 0 } #[doc =
+        " Returns `true` if all of the flags in `other` are contained"] #[doc =
+        " within `self`."] #[inline] pub const fn contains(& self, other : Self) -> bool
+        { self.bits & other.bits == other.bits } #[doc =
+        " Inserts the specified flags in-place."] #[inline] pub fn insert(& mut self,
+        other : Self) { self.bits |= other.bits; } #[doc =
+        " Removes the specified flags in-place."] #[inline] pub fn remove(& mut self,
+        other : Self) { self.bits &= ! other.bits; } #[doc =
+        " Toggles the specified flags in-place."] #[inline] pub fn toggle(& mut self,
+        other : Self) { self.bits ^= other.bits; } #[doc =
+        " Inserts or removes the specified flags depending on the passed"] #[doc =
+        " value."] #[inline] pub fn set(& mut self, other : Self, value : bool) { if
+        value { self.insert(other); } else { self.remove(other); } } #[doc =
+        " Returns the intersection between the flags in `self` and"] #[doc = " `other`."]
+        #[inline] pub const fn intersection(self, other : Self) -> Self { Self { bits :
+        self.bits & other.bits } } #[doc =
+        " Returns the union of the flags in `self` and `other`."] #[inline] pub const fn
+        union(self, other : Self) -> Self { Self { bits : self.bits | other.bits } }
+        #[doc = " Returns the difference between the flags in `self` and `other`."]
+        #[inline] pub const fn difference(self, other : Self) -> Self { Self { bits :
+        self.bits & ! other.bits } } #[doc =
+        " Returns the symmetric difference between the flags in `self` and"] #[doc =
+        " `other`."] #[inline] pub const fn symmetric_difference(self, other : Self) ->
+        Self { Self { bits : self.bits ^ other.bits } } #[doc =
+        " Returns the complement of this set of flags."] #[inline] pub const fn
+        complement(self) -> Self { Self::from_bits_truncate(! self.bits) } } impl
+        ::core::ops::BitOr for $Name { type Output = Self; #[inline] fn bitor(self, other
+        : Self) -> Self { self.union(other) } } impl ::core::ops::BitOrAssign for $Name {
+        #[inline] fn bitor_assign(& mut self, other : Self) { self.insert(other) } } impl
+        ::core::ops::BitAnd for $Name { type Output = Self; #[inline] fn bitand(self,
+        other : Self) -> Self { self.intersection(other) } } impl
+        ::core::ops::BitAndAssign for $Name { #[inline] fn bitand_assign(& mut self,
+        other : Self) { self.bits &= other.bits } } impl ::core::ops::BitXor for $Name {
+        type Output = Self; #[inline] fn bitxor(self, other : Self) -> Self { self
+        .symmetric_difference(other) } } impl ::core::ops::BitXorAssign for $Name {
+        #[inline] fn bitxor_assign(& mut self, other : Self) { self.toggle(other) } }
+        impl ::core::ops::Sub for $Name { type Output = Self; #[inline] fn sub(self,
+        other : Self) -> Self { self.difference(other) } } impl ::core::ops::SubAssign
+        for $Name { #[inline] fn sub_assign(& mut self, other : Self) { self
+        .remove(other) } } impl ::core::ops::Not for $Name { type Output = Self;
+        #[inline] fn not(self) -> Self { self.complement() } } impl ::core::iter::Extend
+        <$Name > for $Name { fn extend < T : ::core::iter::IntoIterator < Item = Self >>
+        (& mut self, iterator : T) { for item in iterator { self.insert(item) } } } impl
+        ::core::iter::FromIterator <$Name > for $Name { fn from_iter < T :
+        ::core::iter::IntoIterator < Item = Self >> (iterator : T) -> Self { let mut
+        result = Self::empty(); result.extend(iterator); result } } impl
+        ::core::fmt::Binary for $Name { fn fmt(& self, f : & mut ::core::fmt::Formatter
+        <'_ >) -> ::core::fmt::Result { ::core::fmt::Binary::fmt(& self.bits, f) } } impl
+        ::core::fmt::Octal for $Name { fn fmt(& self, f : & mut ::core::fmt::Formatter
+        <'_ >) -> ::core::fmt::Result { ::core::fmt::Octal::fmt(& self.bits, f) } } impl
+        ::core::fmt::LowerHex for $Name { fn fmt(& self, f : & mut ::core::fmt::Formatter
+        <'_ >) -> ::core::fmt::Result { ::core::fmt::LowerHex::fmt(& self.bits, f) } }
+        impl ::core::fmt::UpperHex for $Name { fn fmt(& self, f : & mut
+        ::core::fmt::Formatter <'_ >) -> ::core::fmt::Result {
+        ::core::fmt::UpperHex::fmt(& self.bits, f) } }
+    };
+}
 pub mod atomics;
 pub mod bitflags;
 pub mod braced_imports;

--- a/src/backends/rust/bitflags_impl.rs
+++ b/src/backends/rust/bitflags_impl.rs
@@ -1,0 +1,283 @@
+// Derived from the `bitflags` crate (https://github.com/bitflags/bitflags),
+// licensed under Apache-2.0/MIT. Original copyright: The Rust Project
+// Developers.
+//
+// This file is `include_str!`-ed into pyxis's Rust backend and emitted inline
+// into the generated crate root (lib.rs) whenever the crate contains any
+// bitflags definition. It is a freestanding reimplementation of the subset of
+// `bitflags::bitflags!` that Pyxis uses, so generated crates don't have to
+// depend on the `bitflags` crate.
+//
+// Contents are valid as items in a crate root. Paths reference `::core::...`
+// explicitly to avoid depending on the prelude.
+#[macro_export]
+macro_rules! __bitflags {
+    (
+        $(#[$outer:meta])*
+        $vis:vis struct $Name:ident : $T:ty {
+            $(
+                $(#[$inner:meta])*
+                const $Flag:ident = $value:expr;
+            )*
+        }
+    ) => {
+        $(#[$outer])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[repr(transparent)]
+        $vis struct $Name {
+            bits: $T,
+        }
+
+        #[allow(dead_code)]
+        impl $Name {
+            $(
+                $(#[$inner])*
+                $vis const $Flag: Self = Self { bits: $value };
+            )*
+
+            /// Returns an empty set of flags.
+            #[inline]
+            pub const fn empty() -> Self {
+                Self { bits: 0 }
+            }
+
+            /// Returns the set containing all flags.
+            pub const fn all() -> Self {
+                Self { bits: 0 $( | Self::$Flag.bits )* }
+            }
+
+            /// Returns the raw value of the flags currently stored.
+            #[inline]
+            pub const fn bits(&self) -> $T {
+                self.bits
+            }
+
+            /// Convert from underlying bit representation, unless that
+            /// representation contains bits that do not correspond to a flag.
+            #[inline]
+            pub const fn from_bits(bits: $T) -> ::core::option::Option<Self> {
+                let truncated = bits & Self::all().bits;
+                if truncated == bits {
+                    ::core::option::Option::Some(Self { bits })
+                } else {
+                    ::core::option::Option::None
+                }
+            }
+
+            /// Convert from underlying bit representation, dropping any bits
+            /// that do not correspond to flags.
+            #[inline]
+            pub const fn from_bits_truncate(bits: $T) -> Self {
+                Self { bits: bits & Self::all().bits }
+            }
+
+            /// Convert from underlying bit representation as is, without
+            /// checking whether any bits that do not correspond to a flag are
+            /// set.
+            #[inline]
+            pub const fn from_bits_retain(bits: $T) -> Self {
+                Self { bits }
+            }
+
+            /// Returns `true` if no flags are currently stored.
+            #[inline]
+            pub const fn is_empty(&self) -> bool {
+                self.bits == 0
+            }
+
+            /// Returns `true` if all flags are currently set.
+            #[inline]
+            pub const fn is_all(&self) -> bool {
+                Self::all().bits | self.bits == self.bits
+            }
+
+            /// Returns `true` if there are flags common to both `self` and
+            /// `other`.
+            #[inline]
+            pub const fn intersects(&self, other: Self) -> bool {
+                self.bits & other.bits != 0
+            }
+
+            /// Returns `true` if all of the flags in `other` are contained
+            /// within `self`.
+            #[inline]
+            pub const fn contains(&self, other: Self) -> bool {
+                self.bits & other.bits == other.bits
+            }
+
+            /// Inserts the specified flags in-place.
+            #[inline]
+            pub fn insert(&mut self, other: Self) {
+                self.bits |= other.bits;
+            }
+
+            /// Removes the specified flags in-place.
+            #[inline]
+            pub fn remove(&mut self, other: Self) {
+                self.bits &= !other.bits;
+            }
+
+            /// Toggles the specified flags in-place.
+            #[inline]
+            pub fn toggle(&mut self, other: Self) {
+                self.bits ^= other.bits;
+            }
+
+            /// Inserts or removes the specified flags depending on the passed
+            /// value.
+            #[inline]
+            pub fn set(&mut self, other: Self, value: bool) {
+                if value {
+                    self.insert(other);
+                } else {
+                    self.remove(other);
+                }
+            }
+
+            /// Returns the intersection between the flags in `self` and
+            /// `other`.
+            #[inline]
+            pub const fn intersection(self, other: Self) -> Self {
+                Self { bits: self.bits & other.bits }
+            }
+
+            /// Returns the union of the flags in `self` and `other`.
+            #[inline]
+            pub const fn union(self, other: Self) -> Self {
+                Self { bits: self.bits | other.bits }
+            }
+
+            /// Returns the difference between the flags in `self` and `other`.
+            #[inline]
+            pub const fn difference(self, other: Self) -> Self {
+                Self { bits: self.bits & !other.bits }
+            }
+
+            /// Returns the symmetric difference between the flags in `self` and
+            /// `other`.
+            #[inline]
+            pub const fn symmetric_difference(self, other: Self) -> Self {
+                Self { bits: self.bits ^ other.bits }
+            }
+
+            /// Returns the complement of this set of flags.
+            #[inline]
+            pub const fn complement(self) -> Self {
+                Self::from_bits_truncate(!self.bits)
+            }
+        }
+
+        impl ::core::ops::BitOr for $Name {
+            type Output = Self;
+
+            #[inline]
+            fn bitor(self, other: Self) -> Self {
+                self.union(other)
+            }
+        }
+
+        impl ::core::ops::BitOrAssign for $Name {
+            #[inline]
+            fn bitor_assign(&mut self, other: Self) {
+                self.insert(other)
+            }
+        }
+
+        impl ::core::ops::BitAnd for $Name {
+            type Output = Self;
+
+            #[inline]
+            fn bitand(self, other: Self) -> Self {
+                self.intersection(other)
+            }
+        }
+
+        impl ::core::ops::BitAndAssign for $Name {
+            #[inline]
+            fn bitand_assign(&mut self, other: Self) {
+                self.bits &= other.bits
+            }
+        }
+
+        impl ::core::ops::BitXor for $Name {
+            type Output = Self;
+
+            #[inline]
+            fn bitxor(self, other: Self) -> Self {
+                self.symmetric_difference(other)
+            }
+        }
+
+        impl ::core::ops::BitXorAssign for $Name {
+            #[inline]
+            fn bitxor_assign(&mut self, other: Self) {
+                self.toggle(other)
+            }
+        }
+
+        impl ::core::ops::Sub for $Name {
+            type Output = Self;
+
+            #[inline]
+            fn sub(self, other: Self) -> Self {
+                self.difference(other)
+            }
+        }
+
+        impl ::core::ops::SubAssign for $Name {
+            #[inline]
+            fn sub_assign(&mut self, other: Self) {
+                self.remove(other)
+            }
+        }
+
+        impl ::core::ops::Not for $Name {
+            type Output = Self;
+
+            #[inline]
+            fn not(self) -> Self {
+                self.complement()
+            }
+        }
+
+        impl ::core::iter::Extend<$Name> for $Name {
+            fn extend<T: ::core::iter::IntoIterator<Item = Self>>(&mut self, iterator: T) {
+                for item in iterator {
+                    self.insert(item)
+                }
+            }
+        }
+
+        impl ::core::iter::FromIterator<$Name> for $Name {
+            fn from_iter<T: ::core::iter::IntoIterator<Item = Self>>(iterator: T) -> Self {
+                let mut result = Self::empty();
+                result.extend(iterator);
+                result
+            }
+        }
+
+        impl ::core::fmt::Binary for $Name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                ::core::fmt::Binary::fmt(&self.bits, f)
+            }
+        }
+
+        impl ::core::fmt::Octal for $Name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                ::core::fmt::Octal::fmt(&self.bits, f)
+            }
+        }
+
+        impl ::core::fmt::LowerHex for $Name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                ::core::fmt::LowerHex::fmt(&self.bits, f)
+            }
+        }
+
+        impl ::core::fmt::UpperHex for $Name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                ::core::fmt::UpperHex::fmt(&self.bits, f)
+            }
+        }
+    };
+}

--- a/src/backends/rust/mod.rs
+++ b/src/backends/rust/mod.rs
@@ -16,6 +16,42 @@ use crate::{
 
 use quote::{ToTokens, quote};
 
+/// A freestanding reimplementation of the subset of `bitflags::bitflags!` that
+/// Pyxis needs, so generated crates don't have to depend on the `bitflags`
+/// crate. Emitted once into the crate root (see [`BITFLAGS_MACRO`]) whenever the
+/// crate contains any `bitflags` definition, and invoked as `__bitflags!` from
+/// every module that defines bitflags.
+///
+/// The generated type is a `#[repr(transparent)]` newtype over the underlying
+/// integer, always `Copy + Clone`, with the usual bitflags API (`contains`,
+/// `insert`, `|`, `&`, `^`, `!`, `from_bits`, ...). It mirrors the ergonomics of
+/// the `bitflags` crate closely enough for typical consumption without pulling
+/// in an external dependency.
+const BITFLAGS_MACRO: &str = include_str!("bitflags_impl.rs");
+
+/// Whether any (Rust-cfg-included) bitflags definition exists anywhere in the
+/// crate. Used to decide whether to emit [`BITFLAGS_MACRO`] into the root
+/// module.
+fn crate_uses_bitflags(
+    semantic_state: &ResolvedSemanticState,
+    cfg_ctx: &crate::parser::cfg::CfgContext,
+) -> bool {
+    let cfg_pass = |cfg: &Option<crate::parser::cfg::CfgPredicate>| match cfg {
+        Some(p) => p.evaluate(cfg_ctx),
+        None => true,
+    };
+    let type_registry = semantic_state.type_registry();
+    semantic_state.modules().values().any(|module| {
+        module
+            .definitions(type_registry)
+            .filter(|d| cfg_pass(&d.cfg))
+            .any(|d| {
+                d.resolved()
+                    .is_some_and(|r| matches!(r.inner, ItemDefinitionInner::Bitflags(_)))
+            })
+    })
+}
+
 pub fn write_module(
     out_dir: &Path,
     key: &ItemPath,
@@ -60,6 +96,10 @@ pub fn write_module(
 
     let mut raw_output = String::new();
 
+    let cfg_ctx = crate::parser::cfg::CfgContext {
+        backend: crate::Backend::Rust,
+    };
+
     // Lint `allow`s cascade to descendant modules, so they only need to live
     // on the root file (lib.rs / the mounted-subtree root); emitting them on
     // the root also overrides a stricter host crate (the innermost level
@@ -76,6 +116,17 @@ pub fn write_module(
     // <https://stackoverflow.com/questions/59247458/is-there-a-stable-way-to-tell-rustfmt-to-skip-an-entire-file#comment138279076_75910283>
     writeln!(raw_output, "#![cfg_attr(any(), rustfmt::skip)]")?;
     writeln!(raw_output, "{}", doc_to_tokens(true, module.doc()))?;
+
+    // Emit the freestanding `__bitflags!` macro definition exactly once, on the
+    // crate root, when the crate contains any bitflags. It is
+    // `#[macro_export]`-ed, so it lands at the crate root regardless of any
+    // module prefix and is callable from every module as `crate::__bitflags!`.
+    // This lets generated crates drop their `bitflags` dependency. It must
+    // follow the inner attributes (`#![...]`) above, since those can only
+    // precede items in a module body.
+    if key.is_empty() && crate_uses_bitflags(semantic_state, &cfg_ctx) {
+        raw_output.push_str(BITFLAGS_MACRO);
+    }
 
     let backends = module.backends.get(&crate::Backend::Rust);
     let prologues = backends
@@ -150,9 +201,6 @@ pub fn write_module(
         writeln!(raw_output, "use {root}::{{{inner}}};")?;
     }
 
-    let cfg_ctx = crate::parser::cfg::CfgContext {
-        backend: crate::Backend::Rust,
-    };
     let cfg_pass = |cfg: &Option<crate::parser::cfg::CfgPredicate>| match cfg {
         Some(p) => p.evaluate(&cfg_ctx),
         None => true,
@@ -739,9 +787,8 @@ fn build_bitflags(
         flags,
         doc,
         type_,
-        copyable,
-        cloneable,
         default,
+        ..
     } = bitflags_definition;
 
     let syn_type = sa_type_to_syn_type(type_, prefix)?;
@@ -776,9 +823,9 @@ fn build_bitflags(
         }
     });
 
-    // Bitflags handles Default differently (via a separate impl block)
-    let extra_derives = build_extra_derives(*copyable, *cloneable, false);
-
+    // The `__bitflags!` macro (emitted into the crate root) provides all the
+    // derives (`Debug`, `Copy`, `Clone`, comparison, `Hash`, ...) and the
+    // bitflags API itself, so we only forward the doc + visibility + flags.
     let syn_fields = flags.iter().map(|flag| {
         let name_ident = str_to_ident(&flag.name);
         let value = flag.value;
@@ -788,8 +835,7 @@ fn build_bitflags(
     });
 
     Ok(quote! {
-        bitflags::bitflags! {
-            #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, #(#extra_derives),*)]
+        crate::__bitflags! {
             #doc
             #visibility struct #name_ident: #syn_type {
                 #(#syn_fields)*


### PR DESCRIPTION
Fixes #88.

Generate a freestanding `__bitflags!` macro that replicates the core bitflags API, so generated crates no longer need the `bitflags` crate as a dependency. The macro is emitted once into the crate root via `#[macro_export]` when any bitflags definition exists, and invoked as `crate::__bitflags!` from every module that defines bitflags.