### PR TITLE
Fix nested array rendering in C++ backend

### DIFF
--- a/codegen_tests/input/math.pyxis
+++ b/codegen_tests/input/math.pyxis
@@ -4,6 +4,12 @@ pub type Matrix4 {
     pub data: [f32; 16],
 }
 
+/// Nested array type: a 3D grid of vectors indexed as `cells[z][y][x]`.
+#[align(4)]
+pub type VectorGrid {
+    pub cells: [[[Vector3; 4]; 3]; 2],
+}
+
 /// 3D vector type
 #[align(4)]
 pub type Vector3 {

--- a/codegen_tests/output/cpp/include/math.hpp
+++ b/codegen_tests/output/cpp/include/math.hpp
@@ -8,6 +8,7 @@
 namespace math {
     struct Matrix4;
     struct Vector3;
+    struct VectorGrid;
 
     /// 4x4 matrix type for transformations
     struct alignas(4) Matrix4 {
@@ -24,4 +25,11 @@ namespace math {
     };
     static_assert(sizeof(Vector3) == 0xC);
     static_assert(alignof(Vector3) == 4);
+
+    /// Nested array type: a 3D grid of vectors indexed as `cells[z][y][x]`.
+    struct alignas(4) VectorGrid {
+        Vector3 cells[2][3][4];
+    };
+    static_assert(sizeof(VectorGrid) == 0x120);
+    static_assert(alignof(VectorGrid) == 4);
 } // namespace math

--- a/codegen_tests/output/json/output.json
+++ b/codegen_tests/output/json/output.json
@@ -4435,7 +4435,7 @@
             "is_base": false,
             "source": {
               "file_index": 20,
-              "line": 10
+              "line": 16
             }
           },
           {
@@ -4452,7 +4452,7 @@
             "is_base": false,
             "source": {
               "file_index": 20,
-              "line": 11
+              "line": 17
             }
           },
           {
@@ -4469,7 +4469,61 @@
             "is_base": false,
             "source": {
               "file_index": 20,
-              "line": 12
+              "line": 18
+            }
+          }
+        ],
+        "associated_functions": [],
+        "vftable": null,
+        "singleton": null,
+        "copyable": false,
+        "cloneable": false,
+        "defaultable": false,
+        "packed": false,
+        "pinned": false
+      },
+      "source": {
+        "file_index": 20,
+        "line": 15
+      }
+    },
+    "math::VectorGrid": {
+      "path": "math::VectorGrid",
+      "visibility": "public",
+      "size": 288,
+      "alignment": 4,
+      "category": "defined",
+      "kind": {
+        "type": "type",
+        "doc": " Nested array type: a 3D grid of vectors indexed as `cells[z][y][x]`.",
+        "fields": [
+          {
+            "visibility": "public",
+            "name": "cells",
+            "doc": null,
+            "type_ref": {
+              "type": "array",
+              "inner": {
+                "type": "array",
+                "inner": {
+                  "type": "array",
+                  "inner": {
+                    "type": "raw",
+                    "path": "math::Vector3"
+                  },
+                  "size": 4
+                },
+                "size": 3
+              },
+              "size": 2
+            },
+            "offset": 0,
+            "size": 288,
+            "alignment": 4,
+            "is_base": false,
+            "source": {
+              "file_index": 20,
+              "line": 10
             }
           }
         ],
@@ -9978,7 +10032,8 @@
       "doc": null,
       "items": [
         "math::Matrix4",
-        "math::Vector3"
+        "math::Vector3",
+        "math::VectorGrid"
       ],
       "submodules": {},
       "functions": [],

--- a/codegen_tests/output/rust/math.rs
+++ b/codegen_tests/output/rust/math.rs
@@ -45,3 +45,25 @@ impl std::convert::AsMut<Vector3> for Vector3 {
         self
     }
 }
+#[repr(C, align(4))]
+/// Nested array type: a 3D grid of vectors indexed as `cells[z][y][x]`.
+pub struct VectorGrid {
+    pub cells: [[[crate::math::Vector3; 4]; 3]; 2],
+}
+fn _VectorGrid_size_check() {
+    unsafe {
+        ::std::mem::transmute::<[u8; 0x120], VectorGrid>([0u8; 0x120]);
+    }
+    unreachable!()
+}
+impl VectorGrid {}
+impl std::convert::AsRef<VectorGrid> for VectorGrid {
+    fn as_ref(&self) -> &VectorGrid {
+        self
+    }
+}
+impl std::convert::AsMut<VectorGrid> for VectorGrid {
+    fn as_mut(&mut self) -> &mut VectorGrid {
+        self
+    }
+}

--- a/src/backends/cpp/render.rs
+++ b/src/backends/cpp/render.rs
@@ -804,12 +804,26 @@ fn render_field_indented(
         return Ok(());
     };
     let field_name = cpp_ident(field_name);
-    // Arrays render as `T name[N]`; function pointers as `R (cc *name)(args)`;
+    // Arrays render as `T name[N1][N2]...` (C++ array dimensions follow the
+    // declarator, outer-to-inner); function pointers as `R (cc *name)(args)`;
     // everything else as a plain `T name`.
     match &region.type_ref {
-        Type::Array(inner, n) => {
-            let inner_text = render_type(inner, ctx)?;
-            writeln!(out, "{pad}{inner_text} {field_name}[{n}];")?;
+        Type::Array(_, _) => {
+            // Walk the nested Array chain to collect every dimension and find
+            // the innermost element type, then emit `T name[N1][N2]...`.
+            let mut dims: Vec<String> = Vec::new();
+            let mut elem = &region.type_ref;
+            while let Type::Array(inner, n) = elem {
+                dims.push(n.to_string());
+                elem = inner;
+            }
+            let inner_text = render_type(elem, ctx)?;
+            let suffix = dims
+                .iter()
+                .map(|d| format!("[{d}]"))
+                .collect::<Vec<_>>()
+                .join("");
+            writeln!(out, "{pad}{inner_text} {field_name}{suffix};")?;
         }
         Type::Function(cc, args, ret) => {
             let decl = render_function_pointer_decl(


### PR DESCRIPTION
## Problem

The C++ backend only emitted the outermost array dimension for nested array types like `[[[u64; 2]; 3]; 15]`, producing `uint64_t m_Counters[15]` instead of `uint64_t m_Counters[15][3][2]`. This made it impossible to build C++ output for definitions with multi-dimensional arrays (e.g. the Just Cause 3 `CpuProfiler`).

## Root cause

`render_field_indented` in `src/backends/cpp/render.rs` matched only the outer `Type::Array(inner, n)`, emitted `[n]`, then called `render_type(inner)` — which deliberately strips array dimensions (it is designed for template-argument contexts where the `[N]` suffix does not belong). Inner dimensions were silently dropped.

## Fix

`render_field_indented` now walks the full `Type::Array` chain, collecting every dimension and finding the innermost element type, then emits them all in C++ declarator order (outer-to-inner): `T name[N1][N2][N3]`.

## Test case

Adds a `VectorGrid` type to the codegen corpus exercising a triple-nested array `[[[Vector3; 4]; 3]; 2]` across all three backends:

- **C++**: `Vector3 cells[2][3][4];` ✓
- **Rust**: `[[[crate::math::Vector3; 4]; 3]; 2]` ✓
- **JSON**: size 288 = 2×3×4×12 ✓

## Verification

- `cargo clippy --all --all-targets --all-features` ✓
- `cargo +nightly fmt --all -- --check` ✓
- `cargo test -p pyxis --features cpp` ✓
- `cargo run --example codegen_tests` (C++ compilation + all backends) ✓
- `cargo doc --no-deps -p codegen_tests` ✓
- Full JC3 defs project generates and compiles cleanly (minus expected `windows.h` deps)