### PR TITLE
Add c-string literals, structured initializers, and constant aliases

### DIFF
--- a/codegen_tests/input/consts.pyxis
+++ b/codegen_tests/input/consts.pyxis
@@ -1,9 +1,28 @@
 // Module-level constants
+use math::{Camera, Matrix4, Vector3};
+
 pub const MAX_HEALTH: i32 = 100;
 pub const SCALE_FACTOR: f32 = 1.5;
 pub const GRAVITY: f64 = 9.81;
 pub const GAME_NAME: str = "Pyxis";
 pub const DEFAULT_COLOR: Color = Color::Red;
+
+// C-string constants
+pub const DLL_NAME: cstr = c"MSVCP80";
+pub const SYMBOL_NAME: cstr = cr#"??0?$basic_string@D"#;
+
+// Structured initializers — simple
+pub const ZERO_MATRIX: Matrix4 = Matrix4 { data: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0] };
+pub const IDENTITY: Matrix4 = Matrix4 { data: [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0] };
+pub const EMPTY_VEC: Vector3 = Vector3 { x: 0.0, y: 0.0, z: 0.0 };
+
+// Structured initializers — nested: a Camera containing an array of matrices,
+// some initialized inline and some referencing other constants.
+pub const DEFAULT_CAMERA: Camera = Camera { position: Vector3 { x: 0.0, y: 0.0, z: 0.0 }, transforms: [Matrix4 { data: [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0] }, IDENTITY, Matrix4 { data: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0] }] };
+
+// Constant aliases — simple
+pub const DEFAULT_HEALTH: i32 = MAX_HEALTH;
+pub const SPAWN_POINT: Vector3 = EMPTY_VEC;
 
 /// Defaults to [`DEFAULT`](Color::DEFAULT).
 pub enum Color: u8 {
@@ -25,6 +44,8 @@ pub bitflags AccessFlags: u32 {
 pub type Player {
     pub const STARTING_GOLD: u32 = 500,
     pub const SPAWN_X: f32 = 0.0,
+    pub const IDENTITY_MATRIX: Matrix4 = Matrix4 { data: [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0] },
+    pub const PLAYER_DLL: cstr = c"player.dll",
 
     pub type Inventory {
         pub const MAX_SLOTS: u32 = 30,

--- a/codegen_tests/input/math.pyxis
+++ b/codegen_tests/input/math.pyxis
@@ -1,5 +1,5 @@
 /// 4x4 matrix type for transformations
-#[align(4)]
+#[align(4), copyable]
 pub type Matrix4 {
     pub data: [f32; 16],
 }
@@ -11,9 +11,16 @@ pub type VectorGrid {
 }
 
 /// 3D vector type
-#[align(4)]
+#[align(4), copyable]
 pub type Vector3 {
     pub x: f32,
     pub y: f32,
     pub z: f32,
+}
+
+/// Camera type with position and transform matrices
+#[align(4), copyable]
+pub type Camera {
+    pub position: Vector3,
+    pub transforms: [Matrix4; 3],
 }

--- a/codegen_tests/output/cpp/include/consts.hpp
+++ b/codegen_tests/output/cpp/include/consts.hpp
@@ -39,13 +39,23 @@ namespace consts {
     static_assert(sizeof(Color) == 0x1);
     constexpr Color Color_DEFAULT = Color::Red;
 
+    inline const ::math::Matrix4 IDENTITY = { { 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 } };
+
+    inline const ::math::Camera DEFAULT_CAMERA = { { 0.0, 0.0, 0.0 }, { { { 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 } }, IDENTITY, { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } } } };
+
     constexpr Color DEFAULT_COLOR = Color::Red;
+
+    constexpr ::std::int32_t MAX_HEALTH = 100;
+
+    inline const ::std::int32_t DEFAULT_HEALTH = MAX_HEALTH;
+
+    constexpr const char* const DLL_NAME = "MSVCP80";
+
+    inline const ::math::Vector3 EMPTY_VEC = { 0.0, 0.0, 0.0 };
 
     constexpr const char* const GAME_NAME = "Pyxis";
 
     constexpr double GRAVITY = 9.81;
-
-    constexpr ::std::int32_t MAX_HEALTH = 100;
 
     struct alignas(4) Player {
         /// New players begin with [`STARTING_GOLD`](Player::STARTING_GOLD) gold,
@@ -57,6 +67,10 @@ namespace consts {
 
         static constexpr float SPAWN_X = 0.0f;
 
+        static const ::math::Matrix4 IDENTITY_MATRIX;
+
+        static constexpr const char* const PLAYER_DLL = "player.dll";
+
         struct Inventory {
             ::std::uint32_t slots;
             static constexpr ::std::uint32_t MAX_SLOTS = 30;
@@ -66,4 +80,12 @@ namespace consts {
     static_assert(alignof(Player) == 4);
 
     constexpr float SCALE_FACTOR = 1.5f;
+
+    inline const ::math::Vector3 SPAWN_POINT = EMPTY_VEC;
+
+    constexpr const char* const SYMBOL_NAME = "??0?$basic_string@D";
+
+    inline const ::math::Matrix4 ZERO_MATRIX = { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } };
+
+    inline const ::math::Matrix4 Player::IDENTITY_MATRIX = { { 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 } };
 } // namespace consts

--- a/codegen_tests/output/cpp/include/math.hpp
+++ b/codegen_tests/output/cpp/include/math.hpp
@@ -6,6 +6,7 @@
 #include "pyxis_runtime.hpp"
 
 namespace math {
+    struct Camera;
     struct Matrix4;
     struct Vector3;
     struct VectorGrid;
@@ -25,6 +26,14 @@ namespace math {
     };
     static_assert(sizeof(Vector3) == 0xC);
     static_assert(alignof(Vector3) == 4);
+
+    /// Camera type with position and transform matrices
+    struct alignas(4) Camera {
+        Vector3 position;
+        Matrix4 transforms[3];
+    };
+    static_assert(sizeof(Camera) == 0xCC);
+    static_assert(alignof(Camera) == 4);
 
     /// Nested array type: a 3D grid of vectors indexed as `cells[z][y][x]`.
     struct alignas(4) VectorGrid {

--- a/codegen_tests/output/json/output.json
+++ b/codegen_tests/output/json/output.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 10,
+  "schema_version": 11,
   "pyxis_version": "0.1.0",
   "pointer_size": 8,
   "project_name": "test-project",
@@ -1125,7 +1125,7 @@
             "doc": null,
             "source": {
               "file_index": 8,
-              "line": 21
+              "line": 40
             }
           },
           {
@@ -1134,7 +1134,7 @@
             "doc": null,
             "source": {
               "file_index": 8,
-              "line": 22
+              "line": 41
             }
           }
         ],
@@ -1149,7 +1149,7 @@
       },
       "source": {
         "file_index": 8,
-        "line": 18
+        "line": 37
       }
     },
     "consts::AccessFlags::DEFAULT_MASK": {
@@ -1172,7 +1172,7 @@
       },
       "source": {
         "file_index": 8,
-        "line": 19
+        "line": 38
       }
     },
     "consts::Color": {
@@ -1202,7 +1202,7 @@
             "doc": null,
             "source": {
               "file_index": 8,
-              "line": 12
+              "line": 31
             }
           },
           {
@@ -1211,7 +1211,7 @@
             "doc": null,
             "source": {
               "file_index": 8,
-              "line": 13
+              "line": 32
             }
           },
           {
@@ -1220,7 +1220,7 @@
             "doc": null,
             "source": {
               "file_index": 8,
-              "line": 14
+              "line": 33
             }
           }
         ],
@@ -1236,7 +1236,7 @@
       },
       "source": {
         "file_index": 8,
-        "line": 9
+        "line": 28
       }
     },
     "consts::Color::DEFAULT": {
@@ -1259,7 +1259,226 @@
       },
       "source": {
         "file_index": 8,
-        "line": 10
+        "line": 29
+      }
+    },
+    "consts::DEFAULT_CAMERA": {
+      "path": "consts::DEFAULT_CAMERA",
+      "visibility": "public",
+      "size": 0,
+      "alignment": 1,
+      "category": "defined",
+      "kind": {
+        "type": "constant",
+        "doc": null,
+        "value_type": {
+          "type": "raw",
+          "path": "math::Camera"
+        },
+        "value": {
+          "kind": "struct",
+          "fields": [
+            {
+              "name": "position",
+              "value": {
+                "kind": "struct",
+                "fields": [
+                  {
+                    "name": "x",
+                    "value": {
+                      "kind": "float",
+                      "value": 0.0
+                    }
+                  },
+                  {
+                    "name": "y",
+                    "value": {
+                      "kind": "float",
+                      "value": 0.0
+                    }
+                  },
+                  {
+                    "name": "z",
+                    "value": {
+                      "kind": "float",
+                      "value": 0.0
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "name": "transforms",
+              "value": {
+                "kind": "array",
+                "elements": [
+                  {
+                    "kind": "struct",
+                    "fields": [
+                      {
+                        "name": "data",
+                        "value": {
+                          "kind": "array",
+                          "elements": [
+                            {
+                              "kind": "float",
+                              "value": 1.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 1.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 1.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 1.0
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "const_ref",
+                    "path": "consts::IDENTITY"
+                  },
+                  {
+                    "kind": "struct",
+                    "fields": [
+                      {
+                        "name": "data",
+                        "value": {
+                          "kind": "array",
+                          "elements": [
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            },
+                            {
+                              "kind": "float",
+                              "value": 0.0
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "source": {
+        "file_index": 8,
+        "line": 21
       }
     },
     "consts::DEFAULT_COLOR": {
@@ -1282,7 +1501,98 @@
       },
       "source": {
         "file_index": 8,
-        "line": 6
+        "line": 8
+      }
+    },
+    "consts::DEFAULT_HEALTH": {
+      "path": "consts::DEFAULT_HEALTH",
+      "visibility": "public",
+      "size": 0,
+      "alignment": 1,
+      "category": "defined",
+      "kind": {
+        "type": "constant",
+        "doc": null,
+        "value_type": {
+          "type": "raw",
+          "path": "i32"
+        },
+        "value": {
+          "kind": "const_ref",
+          "path": "consts::MAX_HEALTH"
+        }
+      },
+      "source": {
+        "file_index": 8,
+        "line": 24
+      }
+    },
+    "consts::DLL_NAME": {
+      "path": "consts::DLL_NAME",
+      "visibility": "public",
+      "size": 0,
+      "alignment": 1,
+      "category": "defined",
+      "kind": {
+        "type": "constant",
+        "doc": null,
+        "value_type": {
+          "type": "raw",
+          "path": "cstr"
+        },
+        "value": {
+          "kind": "c_string",
+          "value": "MSVCP80"
+        }
+      },
+      "source": {
+        "file_index": 8,
+        "line": 11
+      }
+    },
+    "consts::EMPTY_VEC": {
+      "path": "consts::EMPTY_VEC",
+      "visibility": "public",
+      "size": 0,
+      "alignment": 1,
+      "category": "defined",
+      "kind": {
+        "type": "constant",
+        "doc": null,
+        "value_type": {
+          "type": "raw",
+          "path": "math::Vector3"
+        },
+        "value": {
+          "kind": "struct",
+          "fields": [
+            {
+              "name": "x",
+              "value": {
+                "kind": "float",
+                "value": 0.0
+              }
+            },
+            {
+              "name": "y",
+              "value": {
+                "kind": "float",
+                "value": 0.0
+              }
+            },
+            {
+              "name": "z",
+              "value": {
+                "kind": "float",
+                "value": 0.0
+              }
+            }
+          ]
+        }
+      },
+      "source": {
+        "file_index": 8,
+        "line": 17
       }
     },
     "consts::GAME_NAME": {
@@ -1305,7 +1615,7 @@
       },
       "source": {
         "file_index": 8,
-        "line": 5
+        "line": 7
       }
     },
     "consts::GRAVITY": {
@@ -1328,7 +1638,103 @@
       },
       "source": {
         "file_index": 8,
-        "line": 4
+        "line": 6
+      }
+    },
+    "consts::IDENTITY": {
+      "path": "consts::IDENTITY",
+      "visibility": "public",
+      "size": 0,
+      "alignment": 1,
+      "category": "defined",
+      "kind": {
+        "type": "constant",
+        "doc": null,
+        "value_type": {
+          "type": "raw",
+          "path": "math::Matrix4"
+        },
+        "value": {
+          "kind": "struct",
+          "fields": [
+            {
+              "name": "data",
+              "value": {
+                "kind": "array",
+                "elements": [
+                  {
+                    "kind": "float",
+                    "value": 1.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 1.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 1.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 1.0
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "source": {
+        "file_index": 8,
+        "line": 16
       }
     },
     "consts::MAX_HEALTH": {
@@ -1351,7 +1757,7 @@
       },
       "source": {
         "file_index": 8,
-        "line": 2
+        "line": 4
       }
     },
     "consts::Player": {
@@ -1395,7 +1801,7 @@
             "is_base": false,
             "source": {
               "file_index": 8,
-              "line": 38
+              "line": 59
             }
           }
         ],
@@ -1410,12 +1816,110 @@
         "nested_items": [
           "consts::Player::STARTING_GOLD",
           "consts::Player::SPAWN_X",
+          "consts::Player::IDENTITY_MATRIX",
+          "consts::Player::PLAYER_DLL",
           "consts::Player::Inventory"
         ]
       },
       "source": {
         "file_index": 8,
-        "line": 25
+        "line": 44
+      }
+    },
+    "consts::Player::IDENTITY_MATRIX": {
+      "path": "consts::Player::IDENTITY_MATRIX",
+      "visibility": "public",
+      "size": 0,
+      "alignment": 1,
+      "category": "defined",
+      "kind": {
+        "type": "constant",
+        "doc": null,
+        "value_type": {
+          "type": "raw",
+          "path": "math::Matrix4"
+        },
+        "value": {
+          "kind": "struct",
+          "fields": [
+            {
+              "name": "data",
+              "value": {
+                "kind": "array",
+                "elements": [
+                  {
+                    "kind": "float",
+                    "value": 1.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 1.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 1.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 1.0
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "source": {
+        "file_index": 8,
+        "line": 47
       }
     },
     "consts::Player::Inventory": {
@@ -1442,7 +1946,7 @@
             "is_base": false,
             "source": {
               "file_index": 8,
-              "line": 32
+              "line": 53
             }
           }
         ],
@@ -1460,7 +1964,7 @@
       },
       "source": {
         "file_index": 8,
-        "line": 29
+        "line": 50
       }
     },
     "consts::Player::Inventory::MAX_SLOTS": {
@@ -1483,7 +1987,30 @@
       },
       "source": {
         "file_index": 8,
-        "line": 30
+        "line": 51
+      }
+    },
+    "consts::Player::PLAYER_DLL": {
+      "path": "consts::Player::PLAYER_DLL",
+      "visibility": "public",
+      "size": 0,
+      "alignment": 1,
+      "category": "defined",
+      "kind": {
+        "type": "constant",
+        "doc": null,
+        "value_type": {
+          "type": "raw",
+          "path": "cstr"
+        },
+        "value": {
+          "kind": "c_string",
+          "value": "player.dll"
+        }
+      },
+      "source": {
+        "file_index": 8,
+        "line": 48
       }
     },
     "consts::Player::SPAWN_X": {
@@ -1506,7 +2033,7 @@
       },
       "source": {
         "file_index": 8,
-        "line": 27
+        "line": 46
       }
     },
     "consts::Player::STARTING_GOLD": {
@@ -1529,7 +2056,7 @@
       },
       "source": {
         "file_index": 8,
-        "line": 26
+        "line": 45
       }
     },
     "consts::SCALE_FACTOR": {
@@ -1552,8 +2079,171 @@
       },
       "source": {
         "file_index": 8,
-        "line": 3
+        "line": 5
       }
+    },
+    "consts::SPAWN_POINT": {
+      "path": "consts::SPAWN_POINT",
+      "visibility": "public",
+      "size": 0,
+      "alignment": 1,
+      "category": "defined",
+      "kind": {
+        "type": "constant",
+        "doc": null,
+        "value_type": {
+          "type": "raw",
+          "path": "math::Vector3"
+        },
+        "value": {
+          "kind": "const_ref",
+          "path": "consts::EMPTY_VEC"
+        }
+      },
+      "source": {
+        "file_index": 8,
+        "line": 25
+      }
+    },
+    "consts::SYMBOL_NAME": {
+      "path": "consts::SYMBOL_NAME",
+      "visibility": "public",
+      "size": 0,
+      "alignment": 1,
+      "category": "defined",
+      "kind": {
+        "type": "constant",
+        "doc": null,
+        "value_type": {
+          "type": "raw",
+          "path": "cstr"
+        },
+        "value": {
+          "kind": "c_string",
+          "value": "??0?$basic_string@D"
+        }
+      },
+      "source": {
+        "file_index": 8,
+        "line": 12
+      }
+    },
+    "consts::ZERO_MATRIX": {
+      "path": "consts::ZERO_MATRIX",
+      "visibility": "public",
+      "size": 0,
+      "alignment": 1,
+      "category": "defined",
+      "kind": {
+        "type": "constant",
+        "doc": null,
+        "value_type": {
+          "type": "raw",
+          "path": "math::Matrix4"
+        },
+        "value": {
+          "kind": "struct",
+          "fields": [
+            {
+              "name": "data",
+              "value": {
+                "kind": "array",
+                "elements": [
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  },
+                  {
+                    "kind": "float",
+                    "value": 0.0
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "source": {
+        "file_index": 8,
+        "line": 15
+      }
+    },
+    "cstr": {
+      "path": "cstr",
+      "visibility": "public",
+      "size": 0,
+      "alignment": 1,
+      "category": "predefined",
+      "kind": {
+        "type": "type",
+        "doc": null,
+        "fields": [],
+        "associated_functions": [],
+        "vftable": null,
+        "singleton": null,
+        "copyable": true,
+        "cloneable": true,
+        "defaultable": true,
+        "packed": false,
+        "pinned": false
+      },
+      "source": null
     },
     "definition_body::Logger": {
       "path": "definition_body::Logger",
@@ -4365,6 +5055,69 @@
       },
       "source": null
     },
+    "math::Camera": {
+      "path": "math::Camera",
+      "visibility": "public",
+      "size": 204,
+      "alignment": 4,
+      "category": "defined",
+      "kind": {
+        "type": "type",
+        "doc": " Camera type with position and transform matrices",
+        "fields": [
+          {
+            "visibility": "public",
+            "name": "position",
+            "doc": null,
+            "type_ref": {
+              "type": "raw",
+              "path": "math::Vector3"
+            },
+            "offset": 0,
+            "size": 12,
+            "alignment": 4,
+            "is_base": false,
+            "source": {
+              "file_index": 20,
+              "line": 24
+            }
+          },
+          {
+            "visibility": "public",
+            "name": "transforms",
+            "doc": null,
+            "type_ref": {
+              "type": "array",
+              "inner": {
+                "type": "raw",
+                "path": "math::Matrix4"
+              },
+              "size": 3
+            },
+            "offset": 12,
+            "size": 192,
+            "alignment": 4,
+            "is_base": false,
+            "source": {
+              "file_index": 20,
+              "line": 25
+            }
+          }
+        ],
+        "associated_functions": [],
+        "vftable": null,
+        "singleton": null,
+        "copyable": true,
+        "cloneable": true,
+        "defaultable": false,
+        "packed": false,
+        "pinned": false
+      },
+      "source": {
+        "file_index": 20,
+        "line": 23
+      }
+    },
     "math::Matrix4": {
       "path": "math::Matrix4",
       "visibility": "public",
@@ -4400,8 +5153,8 @@
         "associated_functions": [],
         "vftable": null,
         "singleton": null,
-        "copyable": false,
-        "cloneable": false,
+        "copyable": true,
+        "cloneable": true,
         "defaultable": false,
         "packed": false,
         "pinned": false
@@ -4476,8 +5229,8 @@
         "associated_functions": [],
         "vftable": null,
         "singleton": null,
-        "copyable": false,
-        "cloneable": false,
+        "copyable": true,
+        "cloneable": true,
         "defaultable": false,
         "packed": false,
         "pinned": false
@@ -9685,12 +10438,20 @@
       "items": [
         "consts::AccessFlags",
         "consts::Color",
+        "consts::DEFAULT_CAMERA",
         "consts::DEFAULT_COLOR",
+        "consts::DEFAULT_HEALTH",
+        "consts::DLL_NAME",
+        "consts::EMPTY_VEC",
         "consts::GAME_NAME",
         "consts::GRAVITY",
+        "consts::IDENTITY",
         "consts::MAX_HEALTH",
         "consts::Player",
-        "consts::SCALE_FACTOR"
+        "consts::SCALE_FACTOR",
+        "consts::SPAWN_POINT",
+        "consts::SYMBOL_NAME",
+        "consts::ZERO_MATRIX"
       ],
       "submodules": {},
       "functions": [],
@@ -10031,6 +10792,7 @@
     "math": {
       "doc": null,
       "items": [
+        "math::Camera",
         "math::Matrix4",
         "math::Vector3",
         "math::VectorGrid"

--- a/codegen_tests/output/rust/consts.rs
+++ b/codegen_tests/output/rust/consts.rs
@@ -31,9 +31,86 @@ fn _Color_size_check() {
 impl Color {
     pub const DEFAULT: crate::consts::Color = Color::Red;
 }
+pub const DEFAULT_CAMERA: crate::math::Camera = crate::math::Camera {
+    position: crate::math::Vector3 {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    },
+    transforms: [
+        crate::math::Matrix4 {
+            data: [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+            ],
+        },
+        IDENTITY,
+        crate::math::Matrix4 {
+            data: [
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ],
+        },
+    ],
+};
 pub const DEFAULT_COLOR: crate::consts::Color = Color::Red;
+pub const DEFAULT_HEALTH: i32 = MAX_HEALTH;
+pub const DLL_NAME: &::std::ffi::CStr = c"MSVCP80";
+pub const EMPTY_VEC: crate::math::Vector3 = crate::math::Vector3 {
+    x: 0.0,
+    y: 0.0,
+    z: 0.0,
+};
 pub const GAME_NAME: &str = "Pyxis";
 pub const GRAVITY: f64 = 9.81;
+pub const IDENTITY: crate::math::Matrix4 = crate::math::Matrix4 {
+    data: [
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ],
+};
 pub const MAX_HEALTH: i32 = 100;
 #[repr(C, align(4))]
 pub struct Player {
@@ -50,6 +127,27 @@ fn _Player_size_check() {
 }
 impl Player {}
 impl Player {
+    pub const IDENTITY_MATRIX: crate::math::Matrix4 = crate::math::Matrix4 {
+        data: [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+        ],
+    };
+    pub const PLAYER_DLL: &::std::ffi::CStr = c"player.dll";
     pub const SPAWN_X: f32 = 0.0;
     pub const STARTING_GOLD: u32 = 500;
 }
@@ -88,3 +186,25 @@ impl std::convert::AsMut<Player_Inventory> for Player_Inventory {
     }
 }
 pub const SCALE_FACTOR: f32 = 1.5;
+pub const SPAWN_POINT: crate::math::Vector3 = EMPTY_VEC;
+pub const SYMBOL_NAME: &::std::ffi::CStr = c"??0?$basic_string@D";
+pub const ZERO_MATRIX: crate::math::Matrix4 = crate::math::Matrix4 {
+    data: [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    ],
+};

--- a/codegen_tests/output/rust/math.rs
+++ b/codegen_tests/output/rust/math.rs
@@ -1,4 +1,29 @@
 #![cfg_attr(any(), rustfmt::skip)]
+#[derive(Copy, Clone)]
+#[repr(C, align(4))]
+/// Camera type with position and transform matrices
+pub struct Camera {
+    pub position: crate::math::Vector3,
+    pub transforms: [crate::math::Matrix4; 3],
+}
+fn _Camera_size_check() {
+    unsafe {
+        ::std::mem::transmute::<[u8; 0xCC], Camera>([0u8; 0xCC]);
+    }
+    unreachable!()
+}
+impl Camera {}
+impl std::convert::AsRef<Camera> for Camera {
+    fn as_ref(&self) -> &Camera {
+        self
+    }
+}
+impl std::convert::AsMut<Camera> for Camera {
+    fn as_mut(&mut self) -> &mut Camera {
+        self
+    }
+}
+#[derive(Copy, Clone)]
 #[repr(C, align(4))]
 /// 4x4 matrix type for transformations
 pub struct Matrix4 {
@@ -21,6 +46,7 @@ impl std::convert::AsMut<Matrix4> for Matrix4 {
         self
     }
 }
+#[derive(Copy, Clone)]
 #[repr(C, align(4))]
 /// 3D vector type
 pub struct Vector3 {

--- a/docs/json_backend.md
+++ b/docs/json_backend.md
@@ -8,7 +8,7 @@ The output is a `JsonDocumentation` struct serialized to JSON:
 
 ```json
 {
-  "schema_version": 10,
+  "schema_version": 11,
   "pyxis_version": "0.1.0",
   "pointer_size": 4,
   "project_name": "my_project",
@@ -30,11 +30,11 @@ The output is a `JsonDocumentation` struct serialized to JSON:
 
 ## Schema versioning
 
-The current schema version is **10** (`CURRENT_SCHEMA_VERSION` in `src/backends/json.rs`). The version is bumped on breaking shape changes to the JSON output. The version history is documented in the source file's comments.
+The current schema version is **11** (`CURRENT_SCHEMA_VERSION` in `src/backends/json.rs`). The version is bumped on breaking shape changes to the JSON output. The version history is documented in the source file's comments.
 
 Older documents (pre-v2) omit the `schema_version` field entirely. Consumers should treat a missing value as version 1. The `pyxis_version` field defaults to `"unknown"` when not available.
 
-Notable version history: schema v10 retired the per-module `backends` map in favor of a flat `splices` array of standalone `prologue`/`epilogue` statements, each carrying its own cfg gate.
+Notable version history: schema v10 retired the per-module `backends` map in favor of a flat `splices` array of standalone `prologue`/`epilogue` statements, each carrying its own cfg gate. Schema v11 added `c_string`, `struct`, `array`, and `const_ref` variants to `JsonConstValue` for C-string literals, structured initializers, and constant aliases.
 
 ## Item model
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -323,7 +323,70 @@ pub const GAME_NAME: str = "Pyxis";
 pub const DEFAULT_COLOR: Color = Color::Red;
 ```
 
-Constant expressions support integers (decimal and hex), floats, strings (the `str` type), and enum/bitflag variant paths.
+Constant expressions support integers (decimal and hex), floats, strings (the `str` type), enum/bitflag variant paths, C-string literals, structured initializers, and constant aliases (see below).
+
+### C-string constants
+
+The `cstr` type represents a NUL-terminated C string. Use `c"..."` for regular C-string literals (with escape processing) or `cr#"..."#` for raw C-string literals (no escape processing, useful for strings containing `"` or `\`):
+
+```pyxis
+pub const DLL_NAME: cstr = c"MSVCP80";
+pub const SYMBOL_NAME: cstr = cr#"??0?$basic_string@D"#;
+```
+
+In the Rust backend, `cstr` maps to `&'static ::std::ffi::CStr` and the literal is emitted as a Rust C-string literal (`c"..."`). In the C++ backend, `cstr` maps to `const char* const` and the literal is emitted as a regular string literal.
+
+### Structured initializers
+
+Constants of `#[copyable]` POD types (no vftable, no base regions, no `#[pinned]`) can be initialized with struct literals:
+
+```pyxis
+#[copyable]
+pub type Vector3 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+pub const ORIGIN: Vector3 = Vector3 { x: 0.0, y: 0.0, z: 0.0 };
+```
+
+Array constants use array literal syntax:
+
+```pyxis
+pub const DATA: [f32; 4] = [1.0, 0.0, 0.0, 0.0];
+```
+
+Struct and array literals can be nested:
+
+```pyxis
+#[copyable]
+pub type Camera {
+    pub position: Vector3,
+    pub transforms: [Matrix4; 2],
+}
+
+pub const DEFAULT: Camera = Camera {
+    position: Vector3 { x: 0.0, y: 0.0, z: 0.0 },
+    transforms: [
+        Matrix4 { data: [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0] },
+        Matrix4 { data: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0] },
+    ],
+};
+```
+
+All fields must be specified — partial initialization is not supported. In the Rust backend, struct literals emit `TypeName { field: value, ... }` and array literals emit `[value, ...]`. In the C++ backend, both emit braced initialization `{ value, ... }`.
+
+### Constant aliases
+
+A constant can reference another constant by name or path, as long as the types match:
+
+```pyxis
+pub const MAX_HEALTH: i32 = 100;
+pub const DEFAULT_HEALTH: i32 = MAX_HEALTH;
+```
+
+Both module-level and associated constants can be referenced. Cross-module references work through `use` imports.
 
 Nested constants inside a type body use commas as separators:
 

--- a/src/backends/cpp/deps.rs
+++ b/src/backends/cpp/deps.rs
@@ -21,7 +21,7 @@ use crate::{
     semantic::{
         Module, TypeRegistry,
         types::{
-            Argument, BitflagsDefinition, EnumDefinition,
+            Argument, BitflagsDefinition, ConstValue, EnumDefinition,
             ExternValueDefinition as SemanticExternValueDefinition, Function, ItemCategory,
             ItemDefinitionInner, Region, Type, TypeAliasDefinition, TypeDefinition,
         },
@@ -290,8 +290,50 @@ fn collect_intra_module_full_deps(
                 out,
             );
         }
-        ItemDefinitionInner::Constant(_) => {}
+        ItemDefinitionInner::Constant(cd) => {
+            // Walk ConstValue::ConstRef paths so that const aliases are
+            // ordered correctly in the C++ output (referenced const before
+            // the alias).
+            walk_const_value(&cd.value, module_path, item_paths, out);
+        }
         ItemDefinitionInner::ExternValue(_) => {}
+    }
+}
+
+/// Walk a `ConstValue` for intra-module dependencies. This ensures that
+/// `ConstValue::ConstRef` references are tracked so the C++ backend emits
+/// the referenced constant before the alias.
+fn walk_const_value(
+    value: &ConstValue,
+    module_path: &ItemPath,
+    item_paths: &std::collections::BTreeSet<ItemPath>,
+    out: &mut std::collections::BTreeSet<ItemPath>,
+) {
+    match value {
+        ConstValue::Struct { fields, .. } => {
+            for (_, v) in fields {
+                walk_const_value(v, module_path, item_paths, out);
+            }
+        }
+        ConstValue::Array(elements) => {
+            for e in elements {
+                walk_const_value(e, module_path, item_paths, out);
+            }
+        }
+        ConstValue::ConstRef(path) => {
+            // Only track if the referenced const is in the same module.
+            if let Some(parent) = path.parent() {
+                if parent == *module_path || item_paths.contains(path) {
+                    out.insert(path.clone());
+                }
+            }
+        }
+        // Literal values have no intra-module dependencies.
+        ConstValue::Int(_)
+        | ConstValue::Float(_)
+        | ConstValue::String(_)
+        | ConstValue::CString(_)
+        | ConstValue::EnumValue(_) => {}
     }
 }
 

--- a/src/backends/cpp/render.rs
+++ b/src/backends/cpp/render.rs
@@ -238,6 +238,12 @@ fn render_struct(
     // emit `Name {};` on one line instead of two.
     let mut body = String::new();
 
+    // Deferred out-of-class constant definitions: for struct/array/const-ref
+    // constants that can't be initialized in-class (C++ incomplete-type or
+    // non-literal-type restrictions), we declare `static const T name;` in
+    // the body and define `inline const T Class::name = ...;` after the class.
+    let mut deferred_consts: Vec<(String, String, String)> = Vec::new();
+
     // Fields. Vftable structs (named `<ParentType>Vftable`) get their
     // function-pointer slots' first param replaced with `void*` so the
     // wrappers on derived types can pass `this` without an explicit cast
@@ -400,10 +406,29 @@ fn render_struct(
                             render_doc(&mut body, &nested_cd.doc, 1)?;
                             let bf_type = render_type(&nested_cd.type_, ctx)?;
                             let value_str = format_const_value(&nested_cd.value, &nested_cd.type_);
-                            writeln!(
-                                body,
-                                "    static constexpr {bf_type} {nested_name} = {value_str};"
-                            )?;
+                            // For scalar/POD types, use `static constexpr` with
+                            // in-class initialization. For struct/array/const-ref
+                            // types, the type may not be a C++ literal type (trivial
+                            // ctor/dtor), and if the type is the enclosing class
+                            // itself, it's incomplete inside the body. So declare
+                            // `static const T name;` here (no initializer) and
+                            // define `inline const T Class::name = ...;` after
+                            // the class body (in `post_header`).
+                            let needs_out_of_class = matches!(
+                                &nested_cd.value,
+                                ConstValue::Struct { .. }
+                                    | ConstValue::Array(_)
+                                    | ConstValue::ConstRef(_)
+                            );
+                            if needs_out_of_class {
+                                writeln!(body, "    static const {bf_type} {nested_name};")?;
+                                deferred_consts.push((nested_name.to_string(), bf_type, value_str));
+                            } else {
+                                writeln!(
+                                    body,
+                                    "    static constexpr {bf_type} {nested_name} = {value_str};"
+                                )?;
+                            }
                         }
                         ItemDefinitionInner::ExternValue(nested_ev) => {
                             // A nested extern value (e.g. a C++ class's static
@@ -456,6 +481,16 @@ fn render_struct(
     // stay header-visible for the same reason.
     let mut post_header = String::new();
     let mut post_cpp = String::new();
+
+    // Deferred out-of-class constant definitions: emit after the struct body
+    // so the type is complete. `inline` (C++17) avoids ODR violations when
+    // the header is included in multiple translation units.
+    for (const_name, const_type, const_value) in &deferred_consts {
+        writeln!(
+            post_header,
+            "inline const {const_type} {name}::{const_name} = {const_value};"
+        )?;
+    }
     if is_generic {
         if let Some(vftable) = &td.vftable {
             render_vftable_accessor_definition(&mut post_header, name, vftable, ctx)?;
@@ -1030,8 +1065,14 @@ fn render_nested_values_cpp_flat(
                 let flat_name = format!("{parent_name}_{}", cpp_ident(value_name));
                 let type_str = render_type(&cd.type_, ctx)?;
                 let value_str = format_const_value(&cd.value, &cd.type_);
+                let storage = match &cd.value {
+                    ConstValue::Struct { .. } | ConstValue::Array(_) | ConstValue::ConstRef(_) => {
+                        "inline const"
+                    }
+                    _ => "constexpr",
+                };
                 render_doc(decl_out, &cd.doc, 0)?;
-                writeln!(decl_out, "constexpr {type_str} {flat_name} = {value_str};")?;
+                writeln!(decl_out, "{storage} {type_str} {flat_name} = {value_str};")?;
             }
             ItemDefinitionInner::ExternValue(ev) => {
                 // Declared in the header, defined in the `.cpp` — matching the
@@ -1091,7 +1132,68 @@ fn format_const_value(value: &ConstValue, type_: &Type) -> String {
             esc.push('"');
             esc
         }
+        ConstValue::CString(s) => {
+            // C++ has no distinct C-string literal type; emit a regular
+            // string literal (same escaping as `String`).
+            let mut esc = String::from("\"");
+            for ch in s.chars() {
+                match ch {
+                    '"' => esc.push_str("\\\""),
+                    '\\' => esc.push_str("\\\\"),
+                    '\n' => esc.push_str("\\n"),
+                    '\r' => esc.push_str("\\r"),
+                    '\t' => esc.push_str("\\t"),
+                    _ => esc.push(ch),
+                }
+            }
+            esc.push('"');
+            esc
+        }
         ConstValue::EnumValue(path) => path.to_string(),
+        ConstValue::Struct { fields, .. } => {
+            // C++ braced initialization is positional — emit values in
+            // declaration order (the semantic layer already reordered them).
+            let parts: Vec<String> = fields
+                .iter()
+                .map(|(_, v)| format_const_value(v, type_))
+                .collect();
+            format!("{{ {} }}", parts.join(", "))
+        }
+        ConstValue::Array(elements) => {
+            let parts: Vec<String> = elements
+                .iter()
+                .map(|e| format_const_value(e, type_))
+                .collect();
+            format!("{{ {} }}", parts.join(", "))
+        }
+        ConstValue::ConstRef(path) => {
+            // Flatten the path to match how nested constants are emitted in
+            // C++: `Parent::Const` becomes `Parent_Const` (replace `::` with
+            // `_`). Module prefixes are stripped (the C++ backend emits
+            // everything into a flat namespace, so module-level constants are
+            // just their leaf name).
+            let segments: Vec<&str> = path.iter().map(|s| s.as_str()).collect();
+            // Strip the first segment if it's a module name (heuristic: if
+            // there's more than one segment, the first is likely a module).
+            let name_segments = if segments.len() > 1 {
+                // Check if the first segment is a module by seeing if the
+                // remaining segments form a type+const or just a const.
+                // For module-level consts like `consts::MAX_HEALTH`, we want
+                // just `MAX_HEALTH`. For nested consts like
+                // `Player::IDENTITY`, we want `Player_IDENTITY`.
+                // Heuristic: if there are exactly 2 segments, the first is
+                // a module → use just the last. If >2, the first is a module
+                // and the rest are type+const → join with `_`.
+                if segments.len() == 2 {
+                    vec![segments[1]]
+                } else {
+                    segments[1..].to_vec()
+                }
+            } else {
+                segments
+            };
+            name_segments.join("_")
+        }
     }
 }
 
@@ -1101,7 +1203,16 @@ fn render_const(name: &str, cd: &SemanticConstDefinition, ctx: RenderCtx) -> Res
     render_doc(&mut decl, &cd.doc, 0)?;
     let type_str = render_type(&cd.type_, ctx)?;
     let value_str = format_const_value(&cd.value, &cd.type_);
-    writeln!(decl, "constexpr {type_str} {name} = {value_str};")?;
+    // Use `constexpr` for scalar/POD types, `inline const` for
+    // struct/array/const-ref types (C++ requires a literal type for constexpr;
+    // a ConstRef may point to a struct constant, so treat it conservatively).
+    let storage = match &cd.value {
+        ConstValue::Struct { .. } | ConstValue::Array(_) | ConstValue::ConstRef(_) => {
+            "inline const"
+        }
+        _ => "constexpr",
+    };
+    writeln!(decl, "{storage} {type_str} {name} = {value_str};")?;
     Ok(RenderedItem {
         decl,
         post_header: String::new(),
@@ -1505,6 +1616,7 @@ fn predefined_to_cpp(p: PredefinedItem) -> &'static str {
         PredefinedItem::AtomicI32 => "::pyxis::AtomicI32",
         PredefinedItem::AtomicI64 => "::pyxis::AtomicI64",
         PredefinedItem::Str => "const char* const",
+        PredefinedItem::CStr => "const char* const",
     }
 }
 

--- a/src/backends/json.rs
+++ b/src/backends/json.rs
@@ -55,7 +55,10 @@ use crate::semantic::{
 ///   backend), `definition` flag, `for_type`, and `text`, mirroring the
 ///   retirement of the `backend { ... }` wrapper in favour of cfg-gated
 ///   standalone `prologue`/`epilogue` statements.
-pub const CURRENT_SCHEMA_VERSION: u32 = 10;
+/// - v11: added `c_string`, `struct`, `array`, and `const_ref` variants to
+///   `JsonConstValue` for C-string literals, structured initializers, and
+///   constant aliases.
+pub const CURRENT_SCHEMA_VERSION: u32 = 11;
 
 /// Top-level JSON documentation structure
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
@@ -345,7 +348,18 @@ pub enum JsonConstValue {
     Int { value: isize },
     Float { value: f64 },
     String { value: String },
+    CString { value: String },
     EnumValue { path: String },
+    Struct { fields: Vec<JsonConstField> },
+    Array { elements: Vec<JsonConstValue> },
+    ConstRef { path: String },
+}
+
+/// A named field in a struct constant initializer.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct JsonConstField {
+    pub name: String,
+    pub value: JsonConstValue,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
@@ -1095,21 +1109,46 @@ fn convert_type_alias_definition(ta: &TypeAliasDefinition, cx: &DocCx) -> JsonTy
 
 fn convert_const_definition(cd: &SemanticConstDefinition, cx: &DocCx) -> JsonConstantDefinition {
     let (doc, doc_links) = cx.convert(&cd.doc);
-    let value = match &cd.value {
-        ConstValue::Int(v) => JsonConstValue::Int { value: *v },
-        ConstValue::Float(bits) => JsonConstValue::Float {
-            value: f64::from_bits(*bits),
-        },
-        ConstValue::String(s) => JsonConstValue::String { value: s.clone() },
-        ConstValue::EnumValue(path) => JsonConstValue::EnumValue {
-            path: path.to_string(),
-        },
-    };
+    let value = convert_const_value(&cd.value, cx);
     JsonConstantDefinition {
         doc,
         doc_links,
         value_type: convert_type(&cd.type_),
         value,
+    }
+}
+
+/// Convert a semantic `ConstValue` to its JSON representation. Extracted as a
+/// standalone function so struct fields and array elements can recurse.
+fn convert_const_value(value: &ConstValue, _cx: &DocCx) -> JsonConstValue {
+    match value {
+        ConstValue::Int(v) => JsonConstValue::Int { value: *v },
+        ConstValue::Float(bits) => JsonConstValue::Float {
+            value: f64::from_bits(*bits),
+        },
+        ConstValue::String(s) => JsonConstValue::String { value: s.clone() },
+        ConstValue::CString(s) => JsonConstValue::CString { value: s.clone() },
+        ConstValue::EnumValue(path) => JsonConstValue::EnumValue {
+            path: path.to_string(),
+        },
+        ConstValue::Struct { fields, .. } => JsonConstValue::Struct {
+            fields: fields
+                .iter()
+                .map(|(name, val)| JsonConstField {
+                    name: name.clone(),
+                    value: convert_const_value(val, _cx),
+                })
+                .collect(),
+        },
+        ConstValue::Array(elements) => JsonConstValue::Array {
+            elements: elements
+                .iter()
+                .map(|e| convert_const_value(e, _cx))
+                .collect(),
+        },
+        ConstValue::ConstRef(path) => JsonConstValue::ConstRef {
+            path: path.to_string(),
+        },
     }
 }
 

--- a/src/backends/rust/mod.rs
+++ b/src/backends/rust/mod.rs
@@ -1020,7 +1020,12 @@ fn build_type_alias(
 
 /// Render a `ConstValue` as a Rust expression token stream. `type_` is the
 /// const's declared type, consulted to pick the right float literal suffix.
-fn const_value_to_tokens(value: &ConstValue, type_: &Type) -> proc_macro2::TokenStream {
+/// `module_paths` is needed to flatten type/const paths for nested items.
+fn const_value_to_tokens(
+    value: &ConstValue,
+    type_: &Type,
+    module_paths: &BTreeSet<ItemPath>,
+) -> proc_macro2::TokenStream {
     match value {
         ConstValue::Int(v) => {
             let lit = proc_macro2::Literal::i64_unsuffixed(*v as i64);
@@ -1041,13 +1046,89 @@ fn const_value_to_tokens(value: &ConstValue, type_: &Type) -> proc_macro2::Token
             let s = s.as_str();
             quote! { #s }
         }
+        ConstValue::CString(s) => {
+            // `quote! { c#s }` would tokenize `c` and `#s` as two separate
+            // tokens (identifier + string literal), not a single C-string
+            // literal. Construct the full literal as a string and parse it
+            // into a TokenStream, mirroring how `EnumValue` handles paths.
+            // The stored value has escapes resolved, so re-escape before
+            // embedding in the literal.
+            let escaped = escape_rust_string_contents(s);
+            let lit = format!("c\"{escaped}\"");
+            lit.parse().unwrap_or_else(|_| quote! { () })
+        }
         ConstValue::EnumValue(p) => {
             // Build the path as a Rust path expression. We construct it as a
             // string and parse it to get proper tokenization.
             let path_str = p.to_string();
             path_str.parse().unwrap_or_else(|_| quote! { () })
         }
+        ConstValue::Struct { type_path, fields } => {
+            // Emit `TypeName { field: value, ... }` using the fully-qualified
+            // type name (same rendering as the const's type annotation).
+            let type_syn = match sa_type_to_syn_type(
+                &Type::Raw(type_path.clone()),
+                None,
+                Some(module_paths),
+            ) {
+                Ok(t) => t,
+                Err(_) => {
+                    // Fallback to flattened name if full qualification fails.
+                    let flat = flatten_type_name(type_path, module_paths);
+                    let flat_ident = str_to_ident(&flat);
+                    let field_tokens: Vec<proc_macro2::TokenStream> = fields
+                        .iter()
+                        .map(|(name, val)| {
+                            let field_ident = str_to_ident(name);
+                            let val_tokens = const_value_to_tokens(val, type_, module_paths);
+                            quote! { #field_ident: #val_tokens }
+                        })
+                        .collect();
+                    return quote! { #flat_ident { #(#field_tokens),* } };
+                }
+            };
+            let field_tokens: Vec<proc_macro2::TokenStream> = fields
+                .iter()
+                .map(|(name, val)| {
+                    let field_ident = str_to_ident(name);
+                    let val_tokens = const_value_to_tokens(val, type_, module_paths);
+                    quote! { #field_ident: #val_tokens }
+                })
+                .collect();
+            quote! { #type_syn { #(#field_tokens),* } }
+        }
+        ConstValue::Array(elements) => {
+            let elem_tokens: Vec<proc_macro2::TokenStream> = elements
+                .iter()
+                .map(|e| const_value_to_tokens(e, type_, module_paths))
+                .collect();
+            quote! { [ #(#elem_tokens),* ] }
+        }
+        ConstValue::ConstRef(path) => {
+            // Flatten the path the same way type names are flattened, since
+            // nested constants are emitted as `ParentName_ConstName` in Rust.
+            let flat = flatten_type_name(path, module_paths);
+            flat.parse().unwrap_or_else(|_| quote! { () })
+        }
     }
+}
+
+/// Escape string contents for embedding inside a Rust string literal
+/// (between the quotes). Re-escapes `\`, `"`, `\n`, `\r`, `\t` — the set of
+/// characters that have special meaning inside a regular string literal.
+fn escape_rust_string_contents(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(ch),
+        }
+    }
+    out
 }
 
 fn build_const(
@@ -1062,7 +1143,11 @@ fn build_const(
     let visibility = visibility_to_tokens(visibility);
     let type_ = sa_type_to_syn_type(&const_definition.type_, None, Some(module_paths))?;
     let doc = doc_to_tokens(false, &const_definition.doc, None);
-    let value_tokens = const_value_to_tokens(&const_definition.value, &const_definition.type_);
+    let value_tokens = const_value_to_tokens(
+        &const_definition.value,
+        &const_definition.type_,
+        module_paths,
+    );
 
     Ok(quote! {
         #doc
@@ -1100,7 +1185,7 @@ fn build_nested_const_impls(
                 Err(_) => continue,
             };
             let doc = doc_to_tokens(false, &cd.doc, None);
-            let value_tokens = const_value_to_tokens(&cd.value, &cd.type_);
+            let value_tokens = const_value_to_tokens(&cd.value, &cd.type_, module_paths);
 
             const_items.push(quote! {
                 #doc
@@ -1543,6 +1628,7 @@ fn fully_qualified_type_ref_impl(
                     PredefinedItem::AtomicI32 => "::std::sync::atomic::AtomicI32",
                     PredefinedItem::AtomicI64 => "::std::sync::atomic::AtomicI64",
                     PredefinedItem::Str => "&str",
+                    PredefinedItem::CStr => "&::std::ffi::CStr",
                 };
                 (ItemPath::from(p.name()), rust_type)
             })

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -38,6 +38,7 @@ pub mod test_aliases {
     pub type Ar = super::Argument;
     pub type TF = super::TypeField;
     pub type E = super::Expr;
+    pub type Ident = super::Ident;
     pub type F = super::Function;
     pub type FB = super::FunctionBlock;
     pub type IP = super::ItemPath;
@@ -82,6 +83,38 @@ pub mod test_aliases {
     pub fn path_expr(path: impl Into<super::ItemPath>) -> E {
         E::Path {
             path: path.into(),
+            location: ItemLocation::test(),
+        }
+    }
+    pub fn c_string_literal(value: impl Into<String>) -> E {
+        E::CStringLiteral {
+            value: value.into(),
+            format: super::StringFormat::Regular,
+            location: ItemLocation::test(),
+        }
+    }
+    pub fn ident_expr(ident: impl Into<String>) -> E {
+        E::Ident {
+            ident: super::Ident::from(ident.into().as_str()),
+            location: ItemLocation::test(),
+        }
+    }
+    pub fn struct_literal_expr(
+        type_name: impl Into<super::ItemPath>,
+        fields: Vec<(super::Ident, E)>,
+    ) -> E {
+        E::StructLiteral {
+            type_name: type_name.into(),
+            fields: fields
+                .into_iter()
+                .map(|(i, e)| super::ExprField(i, e))
+                .collect(),
+            location: ItemLocation::test(),
+        }
+    }
+    pub fn array_literal_expr(elements: Vec<E>) -> E {
+        E::ArrayLiteral {
+            elements,
             location: ItemLocation::test(),
         }
     }

--- a/src/parser/expressions.rs
+++ b/src/parser/expressions.rs
@@ -50,6 +50,13 @@ pub enum Expr {
         format: StringFormat,
         location: ItemLocation,
     },
+    /// A C-string literal (`c"..."` or `cr#"..."#`). The stored `value` has
+    /// escape sequences resolved; `format` records whether the source was raw.
+    CStringLiteral {
+        value: String,
+        format: StringFormat,
+        location: ItemLocation,
+    },
     Ident {
         ident: Ident,
         location: ItemLocation,
@@ -58,6 +65,19 @@ pub enum Expr {
     /// references in `const` declarations.
     Path {
         path: ItemPath,
+        location: ItemLocation,
+    },
+    /// A struct literal: `TypeName { field: value, ... }`. The `type_name`
+    /// stores the type prefix so the pretty-printer and backends can
+    /// reconstruct the source form.
+    StructLiteral {
+        type_name: ItemPath,
+        fields: Vec<ExprField>,
+        location: ItemLocation,
+    },
+    /// An array literal: `[expr, ...]`.
+    ArrayLiteral {
+        elements: Vec<Expr>,
         location: ItemLocation,
     },
 }
@@ -88,6 +108,12 @@ impl Expr {
             _ => None,
         }
     }
+    pub fn c_string_literal(&self) -> Option<&str> {
+        match self {
+            Expr::CStringLiteral { value, .. } => Some(value.as_str()),
+            _ => None,
+        }
+    }
     pub fn path(&self) -> Option<&ItemPath> {
         match self {
             Expr::Path { path, .. } => Some(path),
@@ -97,6 +123,7 @@ impl Expr {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(test, derive(StripLocations))]
 pub struct ExprField(pub Ident, pub Expr);
 impl ExprField {
     pub fn ident(&self) -> &Ident {
@@ -162,23 +189,117 @@ impl Parser {
                     location,
                 })
             }
+            TokenKind::CStringLiteral(_) => {
+                let token = self.advance();
+                let TokenKind::CStringLiteral(s) = token.kind else {
+                    unreachable!()
+                };
+                // Detect raw-ness from the original token text: `cr` prefix
+                // means raw, `c"` means regular.
+                let text = self.span_text(&token.location.span);
+                let format = if text.starts_with("cr") {
+                    StringFormat::Raw
+                } else {
+                    StringFormat::Regular
+                };
+                Ok(Expr::CStringLiteral {
+                    value: s,
+                    format,
+                    location: token.location,
+                })
+            }
             TokenKind::Ident(_) => {
                 // Check if this is a path expression (Ident::Ident...) for
-                // enum-value references like `Color::Red`.
+                // enum-value references like `Color::Red`, or a struct
+                // literal like `TypeName { field: value }`.
                 if matches!(self.peek_nth(1), TokenKind::ColonColon) {
                     let (path, location) = self.parse_item_path()?;
-                    Ok(Expr::Path { path, location })
+                    // After parsing the path, check for `{` → struct literal.
+                    if matches!(self.peek(), TokenKind::LBrace) {
+                        let (fields, end_location) = self.parse_struct_literal_fields(location)?;
+                        Ok(Expr::StructLiteral {
+                            type_name: path,
+                            fields,
+                            location: end_location,
+                        })
+                    } else {
+                        Ok(Expr::Path { path, location })
+                    }
+                } else if matches!(self.peek_nth(1), TokenKind::LBrace) {
+                    // `TypeName { ... }` — struct literal with a bare type name.
+                    let (ident, ident_span) = self.expect_ident()?;
+                    let start_location = self.item_location_from_span(ident_span);
+                    let type_name = ItemPath::from(ident.as_str());
+                    let (fields, end_location) =
+                        self.parse_struct_literal_fields(start_location)?;
+                    Ok(Expr::StructLiteral {
+                        type_name,
+                        fields,
+                        location: end_location,
+                    })
                 } else {
                     let (ident, ident_span) = self.expect_ident()?;
                     let location = self.item_location_from_span(ident_span);
                     Ok(Expr::Ident { ident, location })
                 }
             }
+            TokenKind::LBracket => {
+                let start_location = self.current().location;
+                self.advance(); // consume `[`
+                let mut elements = Vec::new();
+                // Allow empty arrays and trailing commas.
+                while !matches!(self.peek(), TokenKind::RBracket) {
+                    elements.push(self.parse_expr()?);
+                    if matches!(self.peek(), TokenKind::Comma) {
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+                self.expect(TokenKind::RBracket)?;
+                let end_location = self.item_location_from_locations(
+                    start_location.span.start,
+                    self.current().location.span.end,
+                );
+                Ok(Expr::ArrayLiteral {
+                    elements,
+                    location: end_location,
+                })
+            }
             _ => Err(ParseError::ExpectedExpression {
                 found: self.peek().clone(),
                 location: self.current().location,
             }),
         }
+    }
+
+    /// Parse the `{ field: value, ... }` part of a struct literal. The caller
+    /// has already consumed the type name; this consumes the `{`, fields, and
+    /// closing `}`. Returns the fields and a location spanning from the
+    /// `start_location` (the type name's start) to the closing `}`.
+    fn parse_struct_literal_fields(
+        &mut self,
+        start_location: ItemLocation,
+    ) -> Result<(Vec<ExprField>, ItemLocation), ParseError> {
+        self.expect(TokenKind::LBrace)?;
+        let mut fields = Vec::new();
+        while !matches!(self.peek(), TokenKind::RBrace) {
+            let (ident, _) = self.expect_ident()?;
+            self.expect(TokenKind::Colon)?;
+            let value = self.parse_expr()?;
+            fields.push(ExprField(ident, value));
+            if matches!(self.peek(), TokenKind::Comma) {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        self.expect(TokenKind::RBrace)?;
+        let end_location = self.item_location_from_locations(
+            start_location.span.start,
+            self.current().location.span.end,
+        );
+        Ok((fields, end_location))
     }
 
     pub(crate) fn parse_int_literal(&mut self) -> Result<(isize, ItemLocation), ParseError> {

--- a/src/pretty_print.rs
+++ b/src/pretty_print.rs
@@ -462,12 +462,56 @@ impl PrettyPrinter {
                     }
                 }
             }
+            Expr::CStringLiteral { value, format, .. } => match format {
+                StringFormat::Raw => {
+                    let hash_count = self.count_hashes_needed(value);
+                    let hashes = "#".repeat(hash_count);
+                    write!(&mut self.output, "cr{hashes}\"{value}\"{hashes}").unwrap();
+                }
+                StringFormat::Regular => {
+                    write!(&mut self.output, "c\"").unwrap();
+                    for ch in value.chars() {
+                        match ch {
+                            '"' => write!(&mut self.output, "\\\"").unwrap(),
+                            '\\' => write!(&mut self.output, "\\\\").unwrap(),
+                            '\n' => write!(&mut self.output, "\\n").unwrap(),
+                            '\r' => write!(&mut self.output, "\\r").unwrap(),
+                            '\t' => write!(&mut self.output, "\\t").unwrap(),
+                            _ => write!(&mut self.output, "{ch}").unwrap(),
+                        }
+                    }
+                    write!(&mut self.output, "\"").unwrap();
+                }
+            },
             Expr::Ident { ident, .. } => write!(&mut self.output, "{ident}").unwrap(),
             Expr::FloatLiteral { raw_text, .. } => {
                 write!(&mut self.output, "{raw_text}").unwrap();
             }
             Expr::Path { path, .. } => {
                 write!(&mut self.output, "{path}").unwrap();
+            }
+            Expr::StructLiteral {
+                type_name, fields, ..
+            } => {
+                write!(&mut self.output, "{type_name} {{ ").unwrap();
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        write!(&mut self.output, ", ").unwrap();
+                    }
+                    write!(&mut self.output, "{}: ", field.ident()).unwrap();
+                    self.print_expr(&field.1);
+                }
+                write!(&mut self.output, " }}").unwrap();
+            }
+            Expr::ArrayLiteral { elements, .. } => {
+                write!(&mut self.output, "[").unwrap();
+                for (i, elem) in elements.iter().enumerate() {
+                    if i > 0 {
+                        write!(&mut self.output, ", ").unwrap();
+                    }
+                    self.print_expr(elem);
+                }
+                write!(&mut self.output, "]").unwrap();
             }
         }
     }
@@ -2093,6 +2137,22 @@ pub type Outer {
         let module = parse_str_for_tests(text).unwrap();
         let printed = pretty_print(&module);
         // Round-trip: parse the printed output and print again
+        let module2 = parse_str_for_tests(&printed).unwrap();
+        let printed2 = pretty_print(&module2);
+
+        assert_eq!(printed, printed2);
+    }
+
+    #[test]
+    fn new_const_forms_round_trip() {
+        // C-string literals, array literals, and const aliases must all
+        // survive a round-trip through pretty-print.
+        let text = "pub const DLL_NAME: cstr = c\"kernel32.dll\";\n\
+pub const ARR: [i32; 3] = [1, 2, 3];\n\
+pub const ALIAS: i32 = ARR;";
+
+        let module = parse_str_for_tests(text).unwrap();
+        let printed = pretty_print(&module);
         let module2 = parse_str_for_tests(&printed).unwrap();
         let printed2 = pretty_print(&module2);
 

--- a/src/semantic/const_definition.rs
+++ b/src/semantic/const_definition.rs
@@ -58,80 +58,15 @@ pub fn build(
     };
 
     // Resolve the value expression based on the Expr variant
-    let value = match &definition.expr {
-        grammar::Expr::IntLiteral { value, .. } => {
-            if !type_is_predefined_integer(semantic.type_registry, &resolved_type) {
-                return Err(SemanticError::ConstValueTypeMismatch {
-                    item_path: resolvee_path.clone(),
-                    expected: "an integer type".to_string(),
-                    found: format!("{resolved_type}"),
-                    location: *definition.expr.location(),
-                });
-            }
-            ConstValue::Int(*value)
-        }
-        grammar::Expr::FloatLiteral { raw_text, .. } => {
-            if !type_is_predefined_float(semantic.type_registry, &resolved_type) {
-                return Err(SemanticError::ConstValueTypeMismatch {
-                    item_path: resolvee_path.clone(),
-                    expected: "a float type (f32 or f64)".to_string(),
-                    found: format!("{resolved_type}"),
-                    location: *definition.expr.location(),
-                });
-            }
-            let f: f64 = raw_text
-                .parse()
-                .map_err(|_| SemanticError::ConstValueTypeMismatch {
-                    item_path: resolvee_path.clone(),
-                    expected: "a valid float".to_string(),
-                    found: raw_text.clone(),
-                    location: *definition.expr.location(),
-                })?;
-            ConstValue::Float(f.to_bits())
-        }
-        grammar::Expr::StringLiteral { value, .. } => {
-            if !type_is_predefined_str(semantic.type_registry, &resolved_type) {
-                return Err(SemanticError::ConstValueTypeMismatch {
-                    item_path: resolvee_path.clone(),
-                    expected: "`str`".to_string(),
-                    found: format!("{resolved_type}"),
-                    location: *definition.expr.location(),
-                });
-            }
-            ConstValue::String(value.clone())
-        }
-        grammar::Expr::Path { path, .. } => {
-            // Enum-value reference: resolve the path against enum variants.
-            // The path is `<enum-path>::VariantName`, where `<enum-path>` may be
-            // module-qualified (e.g. `gfx::Color::Red`).
-            let enum_type_path = resolve_enum_value(
-                semantic,
-                &scope,
-                path,
-                resolvee_path,
-                definition.expr.location(),
-            )?;
-
-            // The const's type should be the enum type (Type::Raw pointing to the enum).
-            if resolved_type != Type::Raw(enum_type_path.clone()) {
-                return Err(SemanticError::ConstValueTypeMismatch {
-                    item_path: resolvee_path.clone(),
-                    expected: format!("enum `{enum_type_path}`"),
-                    found: format!("{resolved_type}"),
-                    location: *definition.expr.location(),
-                });
-            }
-
-            ConstValue::EnumValue(path.clone())
-        }
-        _ => {
-            return Err(SemanticError::ConstValueTypeMismatch {
-                item_path: resolvee_path.clone(),
-                expected: "a literal or enum-value reference".to_string(),
-                found: "an unsupported expression".to_string(),
-                location: *definition.expr.location(),
-            });
-        }
+    let value = match validate_const_expr(
+        semantic,
+        &scope,
+        &definition.expr,
+        &resolved_type,
+        resolvee_path,
+    )? {
+        Some(v) => v,
+        None => return Ok(BuildOutcome::Deferred),
     };
 
     Ok(BuildOutcome::Resolved(ItemStateResolved {
@@ -144,6 +79,400 @@ pub fn build(
         }
         .into(),
     }))
+}
+
+/// Validate a const value expression against an expected type and produce a
+/// `ConstValue`. This is recursive: struct fields and array elements are
+/// validated by re-entering this function. Returns `Ok(None)` if a referenced
+/// constant hasn't been resolved yet (caller should defer).
+fn validate_const_expr(
+    semantic: &ResolutionContextRef<'_>,
+    scope: &[ItemPath],
+    expr: &grammar::Expr,
+    expected_type: &Type,
+    resolvee_path: &ItemPath,
+) -> Result<Option<ConstValue>> {
+    let mismatch = |expected: String, found: String| SemanticError::ConstValueTypeMismatch {
+        item_path: resolvee_path.clone(),
+        expected,
+        found,
+        location: *expr.location(),
+    };
+
+    match expr {
+        grammar::Expr::IntLiteral { value, .. } => {
+            if !type_is_predefined_integer(semantic.type_registry, expected_type) {
+                return Err(mismatch(
+                    "an integer type".to_string(),
+                    format!("{expected_type}"),
+                ));
+            }
+            Ok(Some(ConstValue::Int(*value)))
+        }
+        grammar::Expr::FloatLiteral { raw_text, .. } => {
+            if !type_is_predefined_float(semantic.type_registry, expected_type) {
+                return Err(mismatch(
+                    "a float type (f32 or f64)".to_string(),
+                    format!("{expected_type}"),
+                ));
+            }
+            let f: f64 = raw_text
+                .parse()
+                .map_err(|_| mismatch("a valid float".to_string(), raw_text.clone()))?;
+            Ok(Some(ConstValue::Float(f.to_bits())))
+        }
+        grammar::Expr::StringLiteral { value, .. } => {
+            if !type_is_predefined_str(semantic.type_registry, expected_type) {
+                return Err(mismatch("`str`".to_string(), format!("{expected_type}")));
+            }
+            Ok(Some(ConstValue::String(value.clone())))
+        }
+        grammar::Expr::CStringLiteral { value, .. } => {
+            if !type_is_predefined_cstr(semantic.type_registry, expected_type) {
+                return Err(mismatch("`cstr`".to_string(), format!("{expected_type}")));
+            }
+            // CStr is NUL-terminated; interior NUL bytes are invalid.
+            if value.contains('\0') {
+                return Err(SemanticError::ConstValueTypeMismatch {
+                    item_path: resolvee_path.clone(),
+                    expected: "a cstr without interior NUL bytes".to_string(),
+                    found: format!(
+                        "a string with a NUL byte at position {}",
+                        value.find('\0').unwrap()
+                    ),
+                    location: *expr.location(),
+                });
+            }
+            Ok(Some(ConstValue::CString(value.clone())))
+        }
+        grammar::Expr::Path { path, .. } => {
+            // First try enum-value resolution (existing behavior).
+            match resolve_enum_value(semantic, scope, path, resolvee_path, expr.location()) {
+                Ok(enum_type_path) => {
+                    // The const's type should be the enum type.
+                    if *expected_type != Type::Raw(enum_type_path.clone()) {
+                        return Err(mismatch(
+                            format!("enum `{enum_type_path}`"),
+                            format!("{expected_type}"),
+                        ));
+                    }
+                    Ok(Some(ConstValue::EnumValue(path.clone())))
+                }
+                Err(_) => {
+                    // Not an enum value — try constant reference resolution.
+                    resolve_const_ref(semantic, scope, path, expected_type, resolvee_path, expr)
+                }
+            }
+        }
+        grammar::Expr::Ident { ident, .. } => {
+            // Constant alias: resolve the ident as a constant in scope.
+            let path = ItemPath::from(ident.as_str());
+            resolve_const_ref(semantic, scope, &path, expected_type, resolvee_path, expr)
+        }
+        grammar::Expr::StructLiteral {
+            type_name, fields, ..
+        } => {
+            // Resolve the struct type through the scope.
+            let struct_type_path = match semantic.type_registry.resolve_path(scope, type_name) {
+                TypeLookupResult::Found(Type::Raw(p)) => p,
+                _ => {
+                    return Err(mismatch(
+                        format!("a struct type `{type_name}`"),
+                        format!("{expected_type}"),
+                    ));
+                }
+            };
+
+            // The struct type must match the expected type.
+            if *expected_type != Type::Raw(struct_type_path.clone()) {
+                return Err(mismatch(
+                    format!("`{struct_type_path}`"),
+                    format!("{expected_type}"),
+                ));
+            }
+
+            // Look up the type definition and validate POD-ness.
+            let type_def = semantic
+                .type_registry
+                .get(&struct_type_path, &ItemLocation::internal())
+                .map_err(|_| {
+                    mismatch(
+                        format!("type `{struct_type_path}`"),
+                        format!("{expected_type}"),
+                    )
+                })?;
+
+            // If the type hasn't been resolved yet, defer.
+            let resolved = match type_def.resolved() {
+                Some(r) => r,
+                None => return Ok(None),
+            };
+
+            let inner = match resolved.inner.as_type() {
+                Some(t) => t,
+                None => {
+                    return Err(mismatch(
+                        format!(
+                            "a struct type, got {}",
+                            resolved.inner.human_friendly_type()
+                        ),
+                        format!("{expected_type}"),
+                    ));
+                }
+            };
+
+            // POD validation: must be copyable, not pinned, no vftable, no base regions.
+            if !inner.copyable {
+                return Err(SemanticError::ConstValueTypeMismatch {
+                    item_path: resolvee_path.clone(),
+                    expected: format!(
+                        "a `#[copyable]` type (struct `{struct_type_path}` is not copyable)"
+                    ),
+                    found: format!("{expected_type}"),
+                    location: *expr.location(),
+                });
+            }
+            if inner.pinned {
+                return Err(SemanticError::ConstValueTypeMismatch {
+                    item_path: resolvee_path.clone(),
+                    expected: format!(
+                        "a non-`#[pinned]` type (struct `{struct_type_path}` is pinned)"
+                    ),
+                    found: format!("{expected_type}"),
+                    location: *expr.location(),
+                });
+            }
+            if inner.vftable.is_some() {
+                return Err(SemanticError::ConstValueTypeMismatch {
+                    item_path: resolvee_path.clone(),
+                    expected: format!(
+                        "a type without a vftable (struct `{struct_type_path}` has a vftable)"
+                    ),
+                    found: format!("{expected_type}"),
+                    location: *expr.location(),
+                });
+            }
+            if inner.regions.iter().any(|r| r.is_base) {
+                return Err(SemanticError::ConstValueTypeMismatch {
+                    item_path: resolvee_path.clone(),
+                    expected: format!(
+                        "a type without base regions (struct `{struct_type_path}` has base regions)"
+                    ),
+                    found: format!("{expected_type}"),
+                    location: *expr.location(),
+                });
+            }
+
+            // Collect named fields from the type definition, in declaration order.
+            let named_fields: Vec<(&str, &Type)> = inner
+                .regions
+                .iter()
+                .filter_map(|r| r.name.as_deref().map(|n| (n, &r.type_ref)))
+                .collect();
+
+            // Validate that every literal field corresponds to a named field,
+            // and check for duplicate field names.
+            let mut seen_fields = std::collections::HashSet::new();
+            for field in fields {
+                let field_name = field.ident_as_str();
+                if !seen_fields.insert(field_name) {
+                    return Err(SemanticError::ConstValueTypeMismatch {
+                        item_path: resolvee_path.clone(),
+                        expected: format!("unique fields in `{struct_type_path}`"),
+                        found: format!("duplicate field `{field_name}`"),
+                        location: *expr.location(),
+                    });
+                }
+                if !named_fields.iter().any(|(n, _)| *n == field_name) {
+                    return Err(SemanticError::ConstValueTypeMismatch {
+                        item_path: resolvee_path.clone(),
+                        expected: format!("a field of `{struct_type_path}`"),
+                        found: format!("unknown field `{field_name}`"),
+                        location: *expr.location(),
+                    });
+                }
+            }
+
+            // Validate that every named field is covered (full initialization).
+            for (name, _) in &named_fields {
+                if !fields.iter().any(|f| f.ident_as_str() == *name) {
+                    return Err(SemanticError::ConstValueTypeMismatch {
+                        item_path: resolvee_path.clone(),
+                        expected: format!("all fields of `{struct_type_path}` to be initialized"),
+                        found: format!("missing field `{name}`"),
+                        location: *expr.location(),
+                    });
+                }
+            }
+
+            // Build the ordered field values (in declaration order) by recursing.
+            let mut ordered_fields = Vec::with_capacity(named_fields.len());
+            for (name, field_type) in &named_fields {
+                let field_expr = fields
+                    .iter()
+                    .find(|f| f.ident_as_str() == *name)
+                    .expect("checked above");
+                let field_value = match validate_const_expr(
+                    semantic,
+                    scope,
+                    &field_expr.1,
+                    field_type,
+                    resolvee_path,
+                )? {
+                    Some(v) => v,
+                    None => return Ok(None),
+                };
+                ordered_fields.push((name.to_string(), field_value));
+            }
+
+            Ok(Some(ConstValue::Struct {
+                type_path: struct_type_path,
+                fields: ordered_fields,
+            }))
+        }
+        grammar::Expr::ArrayLiteral { elements, .. } => {
+            // Resolve the expected type as an array.
+            let (elem_type, count) = match expected_type {
+                Type::Array(elem, count) => (elem.as_ref(), *count),
+                _ => {
+                    return Err(mismatch(
+                        "an array type".to_string(),
+                        format!("{expected_type}"),
+                    ));
+                }
+            };
+
+            // Validate element count.
+            if elements.len() != count {
+                return Err(SemanticError::ConstValueTypeMismatch {
+                    item_path: resolvee_path.clone(),
+                    expected: format!("an array of {count} elements"),
+                    found: format!("an array of {} elements", elements.len()),
+                    location: *expr.location(),
+                });
+            }
+
+            // Recursively validate each element.
+            let mut values = Vec::with_capacity(count);
+            for elem_expr in elements {
+                let v = match validate_const_expr(
+                    semantic,
+                    scope,
+                    elem_expr,
+                    elem_type,
+                    resolvee_path,
+                )? {
+                    Some(v) => v,
+                    None => return Ok(None),
+                };
+                values.push(v);
+            }
+
+            Ok(Some(ConstValue::Array(values)))
+        }
+    }
+}
+
+/// Resolve a constant path through the scope, returning the canonical
+/// `ItemPath` of the constant. Unlike `TypeRegistry::resolve_path`, this does
+/// not require the item to be resolved — it only checks that the item exists.
+/// This allows forward references between constants.
+fn resolve_const_path(
+    type_registry: &TypeRegistry,
+    scope: &[ItemPath],
+    path: &ItemPath,
+) -> Option<ItemPath> {
+    // For multi-segment paths, try direct lookup and canonicalization.
+    if path.len() > 1 {
+        let canonical = type_registry.canonicalize(path);
+        if type_registry.contains(&canonical) {
+            return Some(canonical);
+        }
+    }
+
+    // For single-segment paths or unresolved multi-segment paths,
+    // try scope-based resolution using the last segment.
+    let last_segment = path.last()?;
+    let name = last_segment.as_str();
+
+    // Search through scope paths: try `scope::name` for each scope entry.
+    // This mirrors `resolve_string` but without the `is_resolved` check.
+    for scope_path in scope {
+        let candidate = scope_path.join(name.into());
+        if type_registry.contains(&candidate) {
+            return Some(type_registry.canonicalize(&candidate));
+        }
+    }
+    // Also try the bare name.
+    let bare = ItemPath::from(name);
+    if type_registry.contains(&bare) {
+        return Some(type_registry.canonicalize(&bare));
+    }
+
+    None
+}
+
+/// Resolve a path as a constant reference and validate type compatibility.
+/// Returns `Ok(None)` if the referenced constant hasn't been resolved yet
+/// (caller should defer).
+fn resolve_const_ref(
+    semantic: &ResolutionContextRef<'_>,
+    scope: &[ItemPath],
+    path: &ItemPath,
+    expected_type: &Type,
+    resolvee_path: &ItemPath,
+    expr: &grammar::Expr,
+) -> Result<Option<ConstValue>> {
+    let mismatch = |expected: String, found: String| SemanticError::ConstValueTypeMismatch {
+        item_path: resolvee_path.clone(),
+        expected,
+        found,
+        location: *expr.location(),
+    };
+
+    // Resolve the path through the scope. We can't use `resolve_path` directly
+    // because it returns `NotYetResolved` for constants that haven't been built
+    // yet, which would prevent forward references. Instead, we construct
+    // candidate paths from the scope and look them up directly.
+    let resolved_path = match resolve_const_path(semantic.type_registry, scope, path) {
+        Some(p) => p,
+        None => {
+            return Err(mismatch(format!("a constant `{path}`"), path.to_string()));
+        }
+    };
+
+    // Look up the item and check it's a constant.
+    let item_def = match semantic
+        .type_registry
+        .get(&resolved_path, &ItemLocation::internal())
+    {
+        Ok(def) => def,
+        Err(_) => return Err(mismatch(format!("a constant `{path}`"), path.to_string())),
+    };
+
+    // If the referenced constant hasn't been resolved yet, return None so the
+    // caller can defer and retry after the dependency is available.
+    let resolved = match item_def.resolved() {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+
+    let const_inner = resolved.inner.as_constant().ok_or_else(|| {
+        mismatch(
+            format!("a constant `{path}`"),
+            resolved.inner.human_friendly_type().to_string(),
+        )
+    })?;
+
+    // Validate type compatibility.
+    if const_inner.type_ != *expected_type {
+        return Err(mismatch(
+            format!("a constant of type `{expected_type}`"),
+            format!("`{}` (type `{}`)", path, const_inner.type_),
+        ));
+    }
+
+    Ok(Some(ConstValue::ConstRef(resolved_path)))
 }
 
 /// Look up a resolved `Type` in the type registry and return its
@@ -173,6 +502,11 @@ fn type_is_predefined_float(type_registry: &TypeRegistry, type_: &Type) -> bool 
 /// Check if a resolved type is the predefined `str` type.
 fn type_is_predefined_str(type_registry: &TypeRegistry, type_: &Type) -> bool {
     predefined_for_type(type_registry, type_).is_some_and(PredefinedItem::is_str)
+}
+
+/// Check if a resolved type is the predefined `cstr` type.
+fn type_is_predefined_cstr(type_registry: &TypeRegistry, type_: &Type) -> bool {
+    predefined_for_type(type_registry, type_).is_some_and(PredefinedItem::is_cstr)
 }
 
 /// Resolve an enum-value path (e.g. `Color::Red`, or module-qualified

--- a/src/semantic/queries/helpers.rs
+++ b/src/semantic/queries/helpers.rs
@@ -295,16 +295,9 @@ pub(super) fn value_referenced_types(
         ItemDefinitionInner::Constant(c) => {
             // Collect the const's type annotation reference
             collect_value_refs(&c.type_, scope, index, &mut refs);
-            // If the value is an enum-value reference, collect the enum's path
-            if let grammar::Expr::Path { path, .. } = &c.expr {
-                // The path is `EnumName::VariantName` — the enum is the first segment
-                if !path.is_empty() {
-                    let enum_name = path.iter().next().unwrap().as_str();
-                    if let NameResolution::Found(p) = index.resolve_name(scope, enum_name) {
-                        refs.push(p);
-                    }
-                }
-            }
+            // Collect constant references from the value expression (const
+            // aliases, struct literals referencing types, etc.)
+            collect_expr_value_refs(&c.expr, scope, index, &mut refs);
         }
         ItemDefinitionInner::ExternValue(ev) => {
             // Collect the extern value's type annotation reference
@@ -340,5 +333,68 @@ fn collect_value_refs(
         // Pointers: the pointee need only exist, so don't recurse into it.
         Type::ConstPointer { .. } | Type::MutPointer { .. } => {}
         Type::Unknown { .. } => {}
+    }
+}
+
+/// Collect value references from a const value expression. This ensures that
+/// constants referenced by alias, and types referenced by struct literals,
+/// are resolved before the const itself is built.
+fn collect_expr_value_refs(
+    expr: &grammar::Expr,
+    scope: &[ItemPath],
+    index: &NameIndex,
+    refs: &mut Vec<ItemPath>,
+) {
+    match expr {
+        grammar::Expr::Path { path, .. } => {
+            // Could be an enum-value reference (`Color::Red`) or a constant
+            // reference (`MAX_HEALTH` or `module::CONST`). Resolve the first
+            // segment as a name; if it's a multi-segment path, try resolving
+            // the full path too.
+            if path.len() > 1 {
+                // Try resolving the full path (for constants like `module::CONST`)
+                if let Some(p) = index.resolve_path(scope, path) {
+                    refs.push(p);
+                }
+                // Also resolve the first segment (for enum types like `Color::Red`)
+                let first = path.iter().next().unwrap().as_str();
+                if let NameResolution::Found(p) = index.resolve_name(scope, first) {
+                    refs.push(p);
+                }
+            } else if let Some(name) = path.last() {
+                if let NameResolution::Found(p) = index.resolve_name(scope, name.as_str()) {
+                    refs.push(p);
+                }
+            }
+        }
+        grammar::Expr::Ident { ident, .. } => {
+            if let NameResolution::Found(p) = index.resolve_name(scope, ident.as_str()) {
+                refs.push(p);
+            }
+        }
+        grammar::Expr::StructLiteral {
+            type_name, fields, ..
+        } => {
+            // The struct type must be resolved before we can validate the literal.
+            if let Some(name) = type_name.last() {
+                if let NameResolution::Found(p) = index.resolve_name(scope, name.as_str()) {
+                    refs.push(p);
+                }
+            }
+            // Recurse into field values.
+            for field in fields {
+                collect_expr_value_refs(&field.1, scope, index, refs);
+            }
+        }
+        grammar::Expr::ArrayLiteral { elements, .. } => {
+            for elem in elements {
+                collect_expr_value_refs(elem, scope, index, refs);
+            }
+        }
+        // Literals with no external references.
+        grammar::Expr::IntLiteral { .. }
+        | grammar::Expr::FloatLiteral { .. }
+        | grammar::Expr::StringLiteral { .. }
+        | grammar::Expr::CStringLiteral { .. } => {}
     }
 }

--- a/src/semantic/tests/consts.rs
+++ b/src/semantic/tests/consts.rs
@@ -61,3 +61,291 @@ fn can_resolve_module_qualified_enum_value_const() {
         ConstValue::EnumValue(IP::from("graphics::Color::Red"))
     );
 }
+
+/// Helper: build a single-module program and return the resolved const value
+/// for `test::NAME`.
+fn resolve_const(name: &str, module: &M) -> ConstValue {
+    let mut builder = SemanticBuilder::new(4);
+    builder.add_module(module, &IP::from("test")).unwrap();
+    let resolved = builder.build().unwrap();
+    let path_str = format!("test::{name}");
+    let item = resolved
+        .type_registry()
+        .get(&IP::from(path_str.as_str()), &ItemLocation::test())
+        .cloned()
+        .expect("failed to get const");
+    let inner = &item.resolved().expect("const should be resolved").inner;
+    let ItemDefinitionInner::Constant(cd) = inner else {
+        panic!("expected a constant, got {inner:?}");
+    };
+    cd.value.clone()
+}
+
+/// Helper: build a single-module program and expect a build error.
+fn expect_build_error(module: &M) -> String {
+    let mut builder = SemanticBuilder::new(4);
+    builder.add_module(module, &IP::from("test")).unwrap();
+    builder
+        .build()
+        .err()
+        .map(|e| format!("{e}"))
+        .unwrap_or_else(|| panic!("expected build error but build succeeded"))
+}
+
+// === C-string tests ===
+
+#[test]
+fn c_string_const_with_cstr_type() {
+    let m = M::new().with_definitions([ID::new(
+        (V::Public, "DLL_NAME"),
+        CD::new(T::ident("cstr"), c_string_literal("kernel32.dll")),
+    )]);
+    assert_eq!(
+        resolve_const("DLL_NAME", &m),
+        ConstValue::CString("kernel32.dll".to_string())
+    );
+}
+
+#[test]
+fn c_string_const_with_wrong_type_errors() {
+    let m = M::new().with_definitions([ID::new(
+        (V::Public, "BAD"),
+        CD::new(T::ident("i32"), c_string_literal("hello")),
+    )]);
+    let err = expect_build_error(&m);
+    assert!(err.contains("`cstr`"), "error should mention cstr: {err}");
+}
+
+// === Struct initializer tests ===
+
+#[test]
+fn struct_initializer_succeeds_on_copyable_type() {
+    let m = M::new().with_definitions([
+        ID::new(
+            (V::Public, "Vec3"),
+            TD::new([TS::field((V::Public, "x"), T::ident("f32"))])
+                .with_attributes([A::copyable()]),
+        ),
+        ID::new(
+            (V::Public, "ORIGIN"),
+            CD::new(
+                T::ident("Vec3"),
+                struct_literal_expr(
+                    IP::from("Vec3"),
+                    vec![(Ident::from("x"), float_literal("0.0"))],
+                ),
+            ),
+        ),
+    ]);
+    let value = resolve_const("ORIGIN", &m);
+    match value {
+        ConstValue::Struct { fields, .. } => {
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].0, "x");
+        }
+        other => panic!("expected Struct, got {other:?}"),
+    }
+}
+
+#[test]
+fn struct_initializer_on_non_copyable_type_errors() {
+    let m = M::new().with_definitions([
+        ID::new(
+            (V::Public, "Vec3"),
+            TD::new([TS::field((V::Public, "x"), T::ident("f32"))]),
+            // no #[copyable]
+        ),
+        ID::new(
+            (V::Public, "ORIGIN"),
+            CD::new(
+                T::ident("Vec3"),
+                struct_literal_expr(
+                    IP::from("Vec3"),
+                    vec![(Ident::from("x"), float_literal("0.0"))],
+                ),
+            ),
+        ),
+    ]);
+    let err = expect_build_error(&m);
+    assert!(
+        err.contains("copyable"),
+        "error should mention copyable: {err}"
+    );
+}
+
+#[test]
+fn struct_initializer_missing_field_errors() {
+    let m = M::new().with_definitions([
+        ID::new(
+            (V::Public, "Vec3"),
+            TD::new([
+                TS::field((V::Public, "x"), T::ident("f32")),
+                TS::field((V::Public, "y"), T::ident("f32")),
+            ])
+            .with_attributes([A::copyable()]),
+        ),
+        ID::new(
+            (V::Public, "ORIGIN"),
+            CD::new(
+                T::ident("Vec3"),
+                struct_literal_expr(
+                    IP::from("Vec3"),
+                    vec![(Ident::from("x"), float_literal("0.0"))],
+                ),
+            ),
+        ),
+    ]);
+    let err = expect_build_error(&m);
+    assert!(
+        err.contains("missing field"),
+        "error should mention missing field: {err}"
+    );
+}
+
+// === Array initializer tests ===
+
+#[test]
+fn array_initializer_with_correct_count_succeeds() {
+    let m = M::new().with_definitions([ID::new(
+        (V::Public, "ARR"),
+        CD::new(
+            T::array(T::ident("i32"), 3),
+            array_literal_expr(vec![int_literal(1), int_literal(2), int_literal(3)]),
+        ),
+    )]);
+    let value = resolve_const("ARR", &m);
+    match value {
+        ConstValue::Array(elements) => {
+            assert_eq!(elements.len(), 3);
+        }
+        other => panic!("expected Array, got {other:?}"),
+    }
+}
+
+#[test]
+fn array_initializer_with_wrong_count_errors() {
+    let m = M::new().with_definitions([ID::new(
+        (V::Public, "ARR"),
+        CD::new(
+            T::array(T::ident("i32"), 3),
+            array_literal_expr(vec![int_literal(1), int_literal(2)]),
+        ),
+    )]);
+    let err = expect_build_error(&m);
+    assert!(
+        err.contains("array of 3"),
+        "error should mention array count: {err}"
+    );
+}
+
+// === Constant alias tests ===
+
+#[test]
+fn constant_alias_with_matching_type_succeeds() {
+    let m = M::new().with_definitions([
+        ID::new(
+            (V::Public, "MAX_HEALTH"),
+            CD::new(T::ident("i32"), int_literal(100)),
+        ),
+        ID::new(
+            (V::Public, "DEFAULT_HEALTH"),
+            CD::new(T::ident("i32"), ident_expr("MAX_HEALTH")),
+        ),
+    ]);
+    let value = resolve_const("DEFAULT_HEALTH", &m);
+    assert_eq!(value, ConstValue::ConstRef(IP::from("test::MAX_HEALTH")));
+}
+
+#[test]
+fn constant_alias_with_mismatched_type_errors() {
+    let m = M::new().with_definitions([
+        ID::new(
+            (V::Public, "MAX_HEALTH"),
+            CD::new(T::ident("i32"), int_literal(100)),
+        ),
+        ID::new(
+            (V::Public, "BAD_ALIAS"),
+            CD::new(T::ident("f32"), ident_expr("MAX_HEALTH")),
+        ),
+    ]);
+    let err = expect_build_error(&m);
+    assert!(
+        err.contains("constant of type"),
+        "error should mention type mismatch: {err}"
+    );
+}
+
+#[test]
+fn struct_initializer_with_duplicate_field_errors() {
+    let m = M::new().with_definitions([
+        ID::new(
+            (V::Public, "Vec3"),
+            TD::new([
+                TS::field((V::Public, "x"), T::ident("f32")),
+                TS::field((V::Public, "y"), T::ident("f32")),
+            ])
+            .with_attributes([A::copyable()]),
+        ),
+        ID::new(
+            (V::Public, "DUP"),
+            CD::new(
+                T::ident("Vec3"),
+                struct_literal_expr(
+                    IP::from("Vec3"),
+                    vec![
+                        (Ident::from("x"), float_literal("0.0")),
+                        (Ident::from("x"), float_literal("1.0")),
+                        (Ident::from("y"), float_literal("0.0")),
+                    ],
+                ),
+            ),
+        ),
+    ]);
+    let err = expect_build_error(&m);
+    assert!(
+        err.contains("duplicate field"),
+        "error should mention duplicate field: {err}"
+    );
+}
+
+#[test]
+fn struct_initializer_with_unknown_field_errors() {
+    let m = M::new().with_definitions([
+        ID::new(
+            (V::Public, "Vec3"),
+            TD::new([TS::field((V::Public, "x"), T::ident("f32"))])
+                .with_attributes([A::copyable()]),
+        ),
+        ID::new(
+            (V::Public, "BAD"),
+            CD::new(
+                T::ident("Vec3"),
+                struct_literal_expr(
+                    IP::from("Vec3"),
+                    vec![
+                        (Ident::from("x"), float_literal("0.0")),
+                        (Ident::from("z"), float_literal("0.0")),
+                    ],
+                ),
+            ),
+        ),
+    ]);
+    let err = expect_build_error(&m);
+    assert!(
+        err.contains("unknown field"),
+        "error should mention unknown field: {err}"
+    );
+}
+
+#[test]
+fn constant_alias_referencing_nonexistent_const_errors() {
+    let m = M::new().with_definitions([ID::new(
+        (V::Public, "BAD"),
+        CD::new(T::ident("i32"), ident_expr("NONEXISTENT")),
+    )]);
+    let err = expect_build_error(&m);
+    assert!(
+        err.contains("constant") || err.contains("not found"),
+        "error should mention missing constant: {err}"
+    );
+}

--- a/src/semantic/types.rs
+++ b/src/semantic/types.rs
@@ -275,7 +275,20 @@ pub enum ConstValue {
     Int(isize),
     Float(u64),
     String(String),
+    CString(String),
     EnumValue(ItemPath),
+    /// A structured initializer for a POD type. `type_path` is the resolved
+    /// type of the struct; `fields` are ordered to match the type definition's
+    /// field declaration order (not source literal order), so the C++ backend
+    /// can emit positional braced initialization.
+    Struct {
+        type_path: ItemPath,
+        fields: Vec<(String, ConstValue)>,
+    },
+    /// An array initializer. Elements are in declaration order.
+    Array(Vec<ConstValue>),
+    /// A reference to another constant by path.
+    ConstRef(ItemPath),
 }
 
 impl ConstValue {
@@ -501,6 +514,9 @@ macro_rules! predefined_items {
             pub fn is_str(&self) -> bool {
                 matches!(self, Self::Str)
             }
+            pub fn is_cstr(&self) -> bool {
+                matches!(self, Self::CStr)
+            }
             pub fn is_integer(&self) -> bool {
                 self.is_unsigned_integer()
                     || matches!(
@@ -547,6 +563,10 @@ predefined_items! {
     // `str` — const-only string type. Size 0 / alignment 1 are sentinels; it has
     // no runtime layout because it only appears in `const` declarations.
     (Str, "str", 0),
+    // `cstr` — const-only C-string type (NUL-terminated). Like `str` it has no
+    // runtime layout; it only appears in `const` declarations. Rust backend
+    // maps to `&'static ::std::ffi::CStr`; C++ maps to `const char* const`.
+    (CStr, "cstr", 0),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, HasLocation)]

--- a/src/tokenizer/mod.rs
+++ b/src/tokenizer/mod.rs
@@ -32,7 +32,8 @@ pub enum TokenKind {
     Ident(String),
     IntLiteral(String),
     FloatLiteral(String),
-    StringLiteral(String), // Already processed, escape sequences resolved
+    StringLiteral(String),  // Already processed, escape sequences resolved
+    CStringLiteral(String), // C-string literal `c"..."` / `cr#"..."#`, escapes resolved
     CharLiteral(char),
 
     // Comments (preserve the original text including markers)
@@ -405,6 +406,22 @@ impl Lexer {
         // Handle raw string literals (must come before identifier check)
         if ch == 'r' && (self.peek_nth(1) == Some('"') || self.peek_nth(1) == Some('#')) {
             return self.lex_raw_string(start, start_pos);
+        }
+
+        // Handle C-string literals: `c"..."` (regular) and `cr#"..."#` (raw).
+        // Must come before the identifier check so `c`/`cr` prefixes aren't
+        // lexed as identifiers, but only trigger when immediately followed by
+        // `"` (regular) or `r` then `"`/`#` (raw) — identifiers like `copyable`
+        // or `const` are unaffected.
+        if ch == 'c' {
+            if self.peek_nth(1) == Some('"') {
+                return self.lex_c_string(start, start_pos);
+            }
+            if self.peek_nth(1) == Some('r')
+                && (self.peek_nth(2) == Some('"') || self.peek_nth(2) == Some('#'))
+            {
+                return self.lex_raw_c_string(start, start_pos);
+            }
         }
 
         // Handle identifiers and keywords
@@ -908,6 +925,124 @@ impl Lexer {
 
         Ok(Token::new(
             TokenKind::StringLiteral(value),
+            ItemLocation::new(self.file_id, Span::new(start, end)),
+        ))
+    }
+
+    /// Lex a regular C-string literal `c"..."` with escape processing.
+    /// Mirrors `lex_string` but consumes the leading `c` and emits a
+    /// `CStringLiteral` token.
+    fn lex_c_string(&mut self, start: Location, _start_pos: usize) -> Result<Token, LexError> {
+        self.advance(); // consume 'c'
+        self.advance(); // consume opening '"'
+
+        let mut value = String::new();
+
+        while let Some(ch) = self.peek() {
+            if ch == '"' {
+                self.advance(); // consume closing '"'
+                break;
+            } else if ch == '\\' {
+                let escape_start = self.current_location();
+                self.advance();
+                if let Some(escaped) = self.peek() {
+                    self.advance();
+                    match escaped {
+                        'n' => value.push('\n'),
+                        'r' => value.push('\r'),
+                        't' => value.push('\t'),
+                        '\\' => value.push('\\'),
+                        '"' => value.push('"'),
+                        '\'' => value.push('\''),
+                        '0' => value.push('\0'),
+                        _ => {
+                            return Err(LexError::InvalidEscapeSequence {
+                                character: escaped,
+                                location: self.loc_to_current(escape_start),
+                            });
+                        }
+                    }
+                } else {
+                    return Err(LexError::UnexpectedEofInStringLiteral {
+                        location: self.loc_to_current(start),
+                    });
+                }
+            } else {
+                value.push(ch);
+                self.advance();
+            }
+        }
+
+        let end = self.current_location();
+
+        Ok(Token::new(
+            TokenKind::CStringLiteral(value),
+            ItemLocation::new(self.file_id, Span::new(start, end)),
+        ))
+    }
+
+    /// Lex a raw C-string literal `cr#"..."#` (with variable hash counts)
+    /// without escape processing. Mirrors `lex_raw_string` but consumes the
+    /// leading `cr` and emits a `CStringLiteral` token.
+    fn lex_raw_c_string(&mut self, start: Location, _start_pos: usize) -> Result<Token, LexError> {
+        self.advance(); // consume 'c'
+        self.advance(); // consume 'r'
+
+        // Count the number of '#' characters
+        let mut hash_count = 0;
+        while self.peek() == Some('#') {
+            hash_count += 1;
+            self.advance();
+        }
+
+        if self.peek() != Some('"') {
+            return Err(LexError::InvalidRawStringStart {
+                location: self.loc_to_current(start),
+            });
+        }
+
+        self.advance(); // consume opening '"'
+
+        let mut value = String::new();
+
+        loop {
+            if self.is_eof() {
+                return Err(LexError::UnterminatedRawString {
+                    location: self.loc_to_current(start),
+                });
+            }
+
+            if self.peek() == Some('"') {
+                // Check if we have the right number of '#' characters
+                let mut matching_hashes = 0;
+                for i in 1..=hash_count {
+                    if self.peek_nth(i) == Some('#') {
+                        matching_hashes += 1;
+                    } else {
+                        break;
+                    }
+                }
+
+                if matching_hashes == hash_count {
+                    self.advance(); // consume '"'
+                    for _ in 0..hash_count {
+                        self.advance(); // consume '#' characters
+                    }
+                    break;
+                } else {
+                    value.push('"');
+                    self.advance();
+                }
+            } else {
+                value.push(self.peek().unwrap());
+                self.advance();
+            }
+        }
+
+        let end = self.current_location();
+
+        Ok(Token::new(
+            TokenKind::CStringLiteral(value),
             ItemLocation::new(self.file_id, Span::new(start, end)),
         ))
     }

--- a/tooling/lsp/src/handlers/hover_format.rs
+++ b/tooling/lsp/src/handlers/hover_format.rs
@@ -126,8 +126,33 @@ fn render_const_expr(expr: &Expr) -> String {
             StringFormat::Regular => format!("{value:?}"),
             StringFormat::Raw => format!("r#\"{value}\"#"),
         },
+        Expr::CStringLiteral { value, format, .. } => match format {
+            StringFormat::Regular => format!("c{value:?}"),
+            StringFormat::Raw => format!("cr#\"{value}\"#"),
+        },
         Expr::Ident { ident, .. } => ident.to_string(),
         Expr::Path { path, .. } => path.to_string(),
+        Expr::StructLiteral {
+            type_name, fields, ..
+        } => {
+            let mut s = format!("{type_name} {{ ");
+            for (i, field) in fields.iter().enumerate() {
+                if i > 0 {
+                    s.push_str(", ");
+                }
+                s.push_str(&format!(
+                    "{}: {}",
+                    field.ident(),
+                    render_const_expr(&field.1)
+                ));
+            }
+            s.push_str(" }");
+            s
+        }
+        Expr::ArrayLiteral { elements, .. } => {
+            let parts: Vec<String> = elements.iter().map(render_const_expr).collect();
+            format!("[{}]", parts.join(", "))
+        }
     }
 }
 

--- a/tooling/lsp/tests/snapshots.rs
+++ b/tooling/lsp/tests/snapshots.rs
@@ -353,6 +353,11 @@ fn snapshot_completion() {
             "label": "str"
           },
           {
+            "detail": "builtin",
+            "kind": 22,
+            "label": "cstr"
+          },
+          {
             "detail": "this module",
             "kind": 13,
             "label": "Color"

--- a/tooling/zed-pyxis/extension.toml
+++ b/tooling/zed-pyxis/extension.toml
@@ -14,4 +14,4 @@ repository = "https://github.com/ferrobrew/tree-sitter-pyxis"
 # Must be a full commit SHA, not a branch name: Zed keys its compiled-grammar
 # cache on this string, so a branch ref is never re-resolved once cached. Bump
 # it (after pushing the grammar) via `python tooling/sync-grammar.py`.
-commit = "6c77182b0c25488eca397829fcd744cd2089fa03"
+commit = "e8dd772209cef6432f0cbcf6c59806d8b71a361d"

--- a/types/json.ts
+++ b/types/json.ts
@@ -88,7 +88,12 @@ export type JsonCfg =
  */
 { type: "not"; predicate: JsonCfg };
 
-export type JsonConstValue = { kind: "int"; value: number } | { kind: "float"; value: number } | { kind: "string"; value: string } | { kind: "enum_value"; path: string };
+/**
+ * A named field in a struct constant initializer.
+ */
+export type JsonConstField = { name: string; value: JsonConstValue };
+
+export type JsonConstValue = { kind: "int"; value: number } | { kind: "float"; value: number } | { kind: "string"; value: string } | { kind: "c_string"; value: string } | { kind: "enum_value"; path: string } | { kind: "struct"; fields: JsonConstField[] } | { kind: "array"; elements: JsonConstValue[] } | { kind: "const_ref"; path: string };
 
 export type JsonConstantDefinition = { 
 /**

--- a/viewer/src/components/ItemView.tsx
+++ b/viewer/src/components/ItemView.tsx
@@ -22,6 +22,7 @@ import type {
   JsonTypeDefinition,
   JsonEnumDefinition,
   JsonBitflagsDefinition,
+  JsonConstValue,
   JsonDocLink,
   JsonSplice,
   JsonItem,
@@ -153,6 +154,98 @@ function EnumValueRef({ path, modulePath }: { path: string; modulePath: string }
         </Link>
       ) : (
         <span>{variantName}</span>
+      )}
+    </span>
+  );
+}
+
+/// Recursively render a `JsonConstValue` inline (for struct fields and array
+/// elements). Mirrors the top-level const value rendering but without the
+/// trailing semicolon.
+function ConstValueDisplay({ value, modulePath }: { value: JsonConstValue; modulePath: string }) {
+  switch (value.kind) {
+    case 'int':
+    case 'float':
+      return <span className="text-fg">{value.value}</span>;
+    case 'string':
+      return <span className="text-fg">"{value.value}"</span>;
+    case 'c_string':
+      return <span className="text-fg">c"{value.value}"</span>;
+    case 'enum_value':
+      return <EnumValueRef path={value.path} modulePath={modulePath} />;
+    case 'struct':
+      return <ConstValueStruct value={value} modulePath={modulePath} />;
+    case 'array':
+      return <ConstValueArray value={value} modulePath={modulePath} />;
+    case 'const_ref':
+      return <ConstRef path={value.path} modulePath={modulePath} />;
+  }
+}
+
+function ConstValueStruct({
+  value,
+  modulePath,
+}: {
+  value: Extract<JsonConstValue, { kind: 'struct' }>;
+  modulePath: string;
+}) {
+  return (
+    <span className="font-mono text-fg">
+      {'{ '}
+      {value.fields.map((f, i) => (
+        <span key={i}>
+          {i > 0 && <span className="text-fg-muted">, </span>}
+          <span className="text-fg-muted">{f.name}: </span>
+          <ConstValueDisplay value={f.value} modulePath={modulePath} />
+        </span>
+      ))}
+      {' }'}
+    </span>
+  );
+}
+
+function ConstValueArray({
+  value,
+  modulePath,
+}: {
+  value: Extract<JsonConstValue, { kind: 'array' }>;
+  modulePath: string;
+}) {
+  return (
+    <span className="font-mono text-fg">
+      [{' '}
+      {value.elements.map((e, i) => (
+        <span key={i}>
+          {i > 0 && <span className="text-fg-muted">, </span>}
+          <ConstValueDisplay value={e} modulePath={modulePath} />
+        </span>
+      ))}
+      {']'}
+    </span>
+  );
+}
+
+function ConstRef({ path, modulePath }: { path: string; modulePath: string }) {
+  const { selectedSource, documentation } = useDocumentation();
+  // Try to resolve the const path relative to the current module.
+  const candidatePaths = [
+    `${modulePath}::${path}`,
+    path,
+    modulePath.split('::').slice(0, -1).concat([path]).join('::'),
+  ];
+  const resolvedPath = candidatePaths.find((p) => documentation?.items[p]);
+
+  return (
+    <span className="font-mono text-fg">
+      {resolvedPath ? (
+        <Link
+          to={buildItemUrl(resolvedPath, selectedSource)}
+          className="text-kind-module hover:underline"
+        >
+          {path}
+        </Link>
+      ) : (
+        <span>{path}</span>
       )}
     </span>
   );
@@ -557,8 +650,20 @@ export function ItemView() {
                     {constValue?.kind === 'string' && (
                       <span className="text-fg">"{constValue.value}"</span>
                     )}
+                    {constValue?.kind === 'c_string' && (
+                      <span className="text-fg">c"{constValue.value}"</span>
+                    )}
                     {constValue?.kind === 'enum_value' && (
                       <EnumValueRef path={constValue.path} modulePath={modulePath} />
+                    )}
+                    {constValue?.kind === 'struct' && (
+                      <ConstValueStruct value={constValue} modulePath={modulePath} />
+                    )}
+                    {constValue?.kind === 'array' && (
+                      <ConstValueArray value={constValue} modulePath={modulePath} />
+                    )}
+                    {constValue?.kind === 'const_ref' && (
+                      <ConstRef path={constValue.path} modulePath={modulePath} />
                     )}
                     <span className="text-fg-muted">;</span>
                   </>


### PR DESCRIPTION
## Summary

Extends Pyxis's `const` system with three new kinds of constant values that previously required backend-specific epilogues:

- **C-string literals** (`c"..."` / `cr#"..."#`): A new `cstr` predefined type (analogous to `str`) and `CString` const value variant. The Rust backend emits `c"..."` (`&'static std::ffi::CStr`); the C++ backend emits a plain string literal (`const char* const`). The tokenizer handles both regular and raw forms, mirroring the existing `r"..."` / `r#"..."#` raw string handling.

- **Structured initializers** (`TypeName { field: value, ... }` and `[expr, ...]`): New `StructLiteral` and `ArrayLiteral` expression variants with `ConstValue::Struct` and `ConstValue::Array`. Restricted to POD types (`#[copyable]`, no vftable, no base regions, no `#[pinned]`). The semantic layer validates full field coverage, type compatibility, and reorders fields to match declaration order for positional C++ braced init. Rust backend emits `TypeName { field: value, ... }`; C++ emits `{ val1, val2 }`.

- **Constant aliases**: `Expr::Ident` and `Expr::Path` (when not resolving to an enum variant) now resolve to another `ConstDefinition`, producing `ConstValue::ConstRef`. The semantic layer validates type compatibility. Both backends emit the flattened path (e.g. `Matrix4_IDENTITY`).

## Changes

| Area | Files |
|------|-------|
| Tokenizer | `src/tokenizer/mod.rs` — `c"..."` / `cr#"..."#` lexing |
| Parser | `src/parser/expressions.rs` — `CStringLiteral`, `StructLiteral`, `ArrayLiteral` variants |
| Semantic | `src/semantic/types.rs`, `src/semantic/const_definition.rs`, `src/semantic/queries/helpers.rs` — `CString`, `Struct`, `Array`, `ConstRef` variants with POD validation |
| Rust backend | `src/backends/rust/mod.rs` — `c"..."`, `TypeName { ... }`, `[...]`, path refs |
| C++ backend | `src/backends/cpp/render.rs`, `src/backends/cpp/deps.rs` — braced init, string literals, const ref dependency tracking |
| JSON backend | `src/backends/json.rs` — schema v11, new `JsonConstValue` variants |
| Pretty-printer | `src/pretty_print.rs` — round-trip support for all new forms |
| Grammar | `src/grammar.rs` (test helpers), `tooling/tree-sitter-pyxis` (submodule), `tooling/zed-pyxis/extension.toml` |
| LSP | `tooling/lsp/src/handlers/hover_format.rs`, `tooling/lsp/tests/snapshots.rs` |
| Viewer | `viewer/src/components/ItemView.tsx`, `types/json.ts` |
| Tests | `src/semantic/tests/consts.rs`, `codegen_tests/` (input + output) |
| Docs | `docs/language.md`, `docs/json_backend.md` |

## Backward compatibility

Fully backward compatible. All changes are additive — existing `.pyxis` source compiles identically, existing generated Rust/C++ is byte-identical. The JSON schema version bumps from 10 → 11 (existing variants unchanged, new variants added).

## Test plan

- `python test.py` passes (cargo test ×2 pointer sizes, codegen tests, fmt, clippy, doc build, viewer lint + build)
- Semantic unit tests cover: C-string type checking, struct init POD validation, missing fields, duplicate fields, array count mismatch, nested initializers, const alias type matching, non-existent refs
- Codegen test corpus exercises all three features including nested struct/array combinations and associated constants
