### PR TITLE
Resolve relative multi-segment type paths

### DIFF
--- a/codegen_tests/input/nested_items.pyxis
+++ b/codegen_tests/input/nested_items.pyxis
@@ -28,5 +28,8 @@ pub type Outer {
     /// A type alias nested inside [`Outer`].
     pub type InnerAlias = u32,
 
+    /// Reference a nested item by its qualified name inside the parent's own
+    /// body.
+    pub inner: Outer::InnerFlags,
     pub field: u32,
 }

--- a/codegen_tests/input/unions.pyxis
+++ b/codegen_tests/input/unions.pyxis
@@ -86,6 +86,8 @@ pub union Outer {
         pub magic: u32,
     },
 
+    /// Reference the nested item by its qualified name inside the union body.
+    pub header: Outer::Header,
     pub raw: u32,
     pub inner: union {
         pub lo: u16,

--- a/codegen_tests/output/cpp/include/consts.hpp
+++ b/codegen_tests/output/cpp/include/consts.hpp
@@ -40,6 +40,11 @@ namespace consts {
     constexpr Color Color_DEFAULT = Color::Red;
 
     struct alignas(4) Player {
+        struct Inventory {
+            ::std::uint32_t slots;
+
+            static constexpr ::std::uint32_t MAX_SLOTS = 30;
+        };
         /// New players begin with [`STARTING_GOLD`](@ref consts::Player::STARTING_GOLD) gold,
         /// spawn at x=[`SPAWN_X`](@ref consts::Player::SPAWN_X), and can hold up to
         /// [`MAX_SLOTS`](@ref consts::Player::Inventory::MAX_SLOTS) items.
@@ -49,12 +54,6 @@ namespace consts {
         static constexpr float SPAWN_X = 0.0f;
         static const ::math::Matrix4 IDENTITY_MATRIX;
         static constexpr const char* const PLAYER_DLL = "player.dll";
-
-        struct Inventory {
-            ::std::uint32_t slots;
-
-            static constexpr ::std::uint32_t MAX_SLOTS = 30;
-        };
     };
     static_assert(sizeof(Player) == 0x4);
     static_assert(alignof(Player) == 4);

--- a/codegen_tests/output/cpp/include/doc_self_links.hpp
+++ b/codegen_tests/output/cpp/include/doc_self_links.hpp
@@ -17,15 +17,14 @@ namespace doc_self_links {
     /// [`Self::Nested`](@ref doc_self_links::Container::Nested), and to a nested type's member as
     /// [`Self::Nested::nested_field`](@ref doc_self_links::Container::Nested::nested_field).
     struct alignas(4) Container {
-        /// A field.
-        ::std::uint32_t field;
-        /// A method.
-        void method() const;
-
         /// A nested type. Its field is [`Self::nested_field`](@ref doc_self_links::Container::Nested::nested_field).
         struct Nested {
             ::std::uint16_t nested_field;
         };
+        /// A field.
+        ::std::uint32_t field;
+        /// A method.
+        void method() const;
     };
     static_assert(sizeof(Container) == 0x4);
     static_assert(alignof(Container) == 4);

--- a/codegen_tests/output/cpp/include/nested_items.hpp
+++ b/codegen_tests/output/cpp/include/nested_items.hpp
@@ -13,9 +13,7 @@ namespace nested_items {
     /// See [`InnerEnum`](@ref nested_items::Outer::InnerEnum), [`InnerType`](@ref nested_items::Outer::InnerType), [`InnerFlags`](@ref nested_items::Outer::InnerFlags), and [`InnerAlias`](@ref nested_items::Outer::InnerAlias).
     ///
     /// You can also qualify them: [`Outer::InnerEnum`](@ref nested_items::Outer::InnerEnum), [`Outer::InnerType`](@ref nested_items::Outer::InnerType).
-    struct alignas(4) Outer {
-        ::std::uint32_t field;
-
+    struct alignas(8) Outer {
         /// An enum nested inside [`Outer`](@ref nested_items::Outer).
         ///
         /// Variants: [`InnerEnum::A`](@ref nested_items::Outer::InnerEnum::A), [`InnerEnum::B`](@ref nested_items::Outer::InnerEnum::B), [`InnerEnum::C`](@ref nested_items::Outer::InnerEnum::C).
@@ -42,7 +40,11 @@ namespace nested_items {
 
         /// A type alias nested inside [`Outer`](@ref nested_items::Outer).
         using InnerAlias = ::std::uint32_t;
+        /// Reference a nested item by its qualified name inside the parent's own
+        /// body.
+        ::nested_items::Outer::InnerFlags inner;
+        ::std::uint32_t field;
     };
-    static_assert(sizeof(Outer) == 0x4);
-    static_assert(alignof(Outer) == 4);
+    static_assert(sizeof(Outer) == 0x8);
+    static_assert(alignof(Outer) == 8);
 } // namespace nested_items

--- a/codegen_tests/output/cpp/include/unions.hpp
+++ b/codegen_tests/output/cpp/include/unions.hpp
@@ -77,14 +77,15 @@ namespace unions {
     /// A union nested inside another union, plus a nested item declaration in a
     /// union body.
     union alignas(4) Outer {
-        ::std::uint32_t raw;
-        OuterInnerUnion inner;
-
         /// A type declared inside a union body. Nested declarations work here
         /// exactly as they do in a `type` body.
         struct Header {
             ::std::uint32_t magic;
         };
+        /// Reference the nested item by its qualified name inside the union body.
+        ::unions::Outer::Header header;
+        ::std::uint32_t raw;
+        OuterInnerUnion inner;
     };
     static_assert(sizeof(Outer) == 0x4);
     static_assert(alignof(Outer) == 4);

--- a/codegen_tests/output/json/output.json
+++ b/codegen_tests/output/json/output.json
@@ -9110,8 +9110,8 @@
     "nested_items::Outer": {
       "path": "nested_items::Outer",
       "visibility": "public",
-      "size": 4,
-      "alignment": 4,
+      "size": 8,
+      "alignment": 8,
       "category": "defined",
       "kind": {
         "type": "type",
@@ -9151,11 +9151,11 @@
         "fields": [
           {
             "visibility": "public",
-            "name": "field",
-            "doc": null,
+            "name": "inner",
+            "doc": " Reference a nested item by its qualified name inside the parent's own\n body.",
             "type_ref": {
               "type": "raw",
-              "path": "u32"
+              "path": "nested_items::Outer::InnerFlags"
             },
             "offset": 0,
             "size": 4,
@@ -9163,7 +9163,24 @@
             "is_base": false,
             "source": {
               "file_index": 26,
-              "line": 31
+              "line": 33
+            }
+          },
+          {
+            "visibility": "public",
+            "name": "field",
+            "doc": null,
+            "type_ref": {
+              "type": "raw",
+              "path": "u32"
+            },
+            "offset": 4,
+            "size": 4,
+            "alignment": 4,
+            "is_base": false,
+            "source": {
+              "file_index": 26,
+              "line": 34
             }
           }
         ],
@@ -12084,6 +12101,23 @@
         "fields": [
           {
             "visibility": "public",
+            "name": "header",
+            "doc": " Reference the nested item by its qualified name inside the union body.",
+            "type_ref": {
+              "type": "raw",
+              "path": "unions::Outer::Header"
+            },
+            "offset": 0,
+            "size": 4,
+            "alignment": 4,
+            "is_base": false,
+            "source": {
+              "file_index": 38,
+              "line": 90
+            }
+          },
+          {
+            "visibility": "public",
             "name": "raw",
             "doc": null,
             "type_ref": {
@@ -12096,7 +12130,7 @@
             "is_base": false,
             "source": {
               "file_index": 38,
-              "line": 89
+              "line": 91
             }
           },
           {
@@ -12113,7 +12147,7 @@
             "is_base": false,
             "source": {
               "file_index": 38,
-              "line": 90
+              "line": 92
             }
           }
         ],
@@ -12199,7 +12233,7 @@
             "is_base": false,
             "source": {
               "file_index": 38,
-              "line": 91
+              "line": 93
             }
           },
           {
@@ -12220,7 +12254,7 @@
             "is_base": false,
             "source": {
               "file_index": 38,
-              "line": 92
+              "line": 94
             }
           }
         ],
@@ -12234,7 +12268,7 @@
       },
       "source": {
         "file_index": 38,
-        "line": 90
+        "line": 92
       }
     },
     "unions::OversizedSlot": {
@@ -12712,7 +12746,7 @@
             "is_base": false,
             "source": {
               "file_index": 38,
-              "line": 100
+              "line": 102
             }
           },
           {
@@ -12733,7 +12767,7 @@
             "is_base": false,
             "source": {
               "file_index": 38,
-              "line": 101
+              "line": 103
             }
           }
         ],
@@ -12747,7 +12781,7 @@
       },
       "source": {
         "file_index": 38,
-        "line": 99
+        "line": 101
       }
     },
     "vftable_indices::IndexedVftable": {

--- a/codegen_tests/output/rust/nested_items.rs
+++ b/codegen_tests/output/rust/nested_items.rs
@@ -1,16 +1,19 @@
 #![cfg_attr(any(), rustfmt::skip)]
-#[repr(C, align(4))]
+#[repr(C, align(8))]
 /// A type with nested declarations.
 ///
 /// See [`InnerEnum`](crate::nested_items::Outer_InnerEnum), [`InnerType`](crate::nested_items::Outer_InnerType), [`InnerFlags`](crate::nested_items::Outer_InnerFlags), and [`InnerAlias`](crate::nested_items::Outer_InnerAlias).
 ///
 /// You can also qualify them: [`Outer::InnerEnum`](crate::nested_items::Outer_InnerEnum), [`Outer::InnerType`](crate::nested_items::Outer_InnerType).
 pub struct Outer {
+    /// Reference a nested item by its qualified name inside the parent's own
+    /// body.
+    pub inner: crate::nested_items::Outer_InnerFlags,
     pub field: u32,
 }
 fn _Outer_size_check() {
     unsafe {
-        ::std::mem::transmute::<[u8; 0x4], Outer>([0u8; 0x4]);
+        ::std::mem::transmute::<[u8; 0x8], Outer>([0u8; 0x8]);
     }
     unreachable!()
 }

--- a/codegen_tests/output/rust/unions.rs
+++ b/codegen_tests/output/rust/unions.rs
@@ -79,6 +79,8 @@ impl ::core::fmt::Debug for InlineScratchDataUnion {
 /// A union nested inside another union, plus a nested item declaration in a
 /// union body.
 pub union Outer {
+    /// Reference the nested item by its qualified name inside the union body.
+    pub header: ::core::mem::ManuallyDrop<crate::unions::Outer_Header>,
     pub raw: ::core::mem::ManuallyDrop<u32>,
     pub inner: ::core::mem::ManuallyDrop<crate::unions::OuterInnerUnion>,
 }

--- a/docs/language.md
+++ b/docs/language.md
@@ -157,7 +157,7 @@ pub type Outer {
 }
 ```
 
-Nested items are accessed as `Outer::InnerEnum` etc. In the Rust backend, nested types are flattened to `Outer_InnerEnum` (rustdoc can't represent true nested types). In the JSON backend, they appear under the parent's `nested_items` with their full paths preserved.
+Nested items are accessed as `Outer::InnerEnum` etc. — both in a `use` and inline wherever a type name appears (e.g. `pub field: Outer::InnerEnum` inside `Outer`'s own body). The qualified spelling is required: a bare nested name (`pub field: InnerEnum`) does not resolve. In the Rust backend, nested types are flattened to `Outer_InnerEnum` (rustdoc can't represent true nested types). In the JSON backend, they appear under the parent's `nested_items` with their full paths preserved.
 
 ### Generated names
 

--- a/src/backends/cpp/deps/mod.rs
+++ b/src/backends/cpp/deps/mod.rs
@@ -607,6 +607,15 @@ fn record_path(
     if &target_module == module_path {
         return;
     }
+    // A nested item's immediate parent is a *type*, not a module, so
+    // `target.parent()` above is `Outer`, not this module. If the target is
+    // nested inside this same module, its definition lives in this module's
+    // own header — no cross-module include or forward decl is needed (and
+    // including `nested_items::Outer.hpp` would name a header that doesn't
+    // exist). Cross-module nested references are not modeled here.
+    if target.starts_with(module_path) {
+        return;
+    }
     match kind {
         EdgeKind::FullDef => {
             deps.include_modules.insert(target_module);

--- a/src/backends/cpp/render/nested.rs
+++ b/src/backends/cpp/render/nested.rs
@@ -12,223 +12,225 @@ use crate::{
     span::ItemLocation,
 };
 
-/// Render nested item declarations (enums, types, bitflags, type aliases,
-/// constants, extern values) inside the struct body. Struct/array/const-ref
-/// constants that need an out-of-class definition are pushed into
-/// `deferred_consts` for the caller to emit after the class body.
-pub(super) fn render_declarations(
+/// Render type-declaring nested items (types, unions, enums, bitflags, type
+/// aliases). These are emitted *before* the parent's fields so that a field
+/// inside the parent may name one of them (`Outer::Inner`). Value items
+/// (constants, extern values) are rendered separately afterwards via
+/// [`render_value_declarations`].
+pub(super) fn render_type_declarations(
+    body: &mut String,
+    nested_item_paths: &[ItemPath],
+    ctx: RenderCtx,
+) -> Result<()> {
+    for nested_path in nested_item_paths {
+        let Ok(nested_item) = ctx.registry.get(nested_path, &ItemLocation::internal()) else {
+            continue;
+        };
+        let Some(nested_resolved) = nested_item.resolved() else {
+            continue;
+        };
+        if !matches!(
+            &nested_resolved.inner,
+            ItemDefinitionInner::Type(_)
+                | ItemDefinitionInner::Union(_)
+                | ItemDefinitionInner::Enum(_)
+                | ItemDefinitionInner::Bitflags(_)
+                | ItemDefinitionInner::TypeAlias(_)
+        ) {
+            continue;
+        }
+        if !body.trim().is_empty() {
+            writeln!(body)?;
+        }
+        let nested_name = nested_path
+            .last()
+            .map(|s| s.as_str().to_string())
+            .unwrap_or_default();
+        let nested_name = super::cpp_ident(&nested_name);
+        match &nested_resolved.inner {
+            ItemDefinitionInner::Type(nested_td) => {
+                super::types::render_doc(body, &nested_td.doc, 1, ctx, &nested_item.location)?;
+                writeln!(body, "    struct {nested_name} {{")?;
+                let nested_had_fields = !nested_td.regions.is_empty();
+                for region in &nested_td.regions {
+                    super::items::render_field_indented(body, region, ctx, false, 2)?;
+                }
+                // Render nested constants inside the nested struct
+                let nested_has_consts = nested_td.nested_item_paths.iter().any(|p| {
+                    ctx.registry
+                        .get(p, &ItemLocation::internal())
+                        .ok()
+                        .and_then(|i| i.resolved())
+                        .is_some_and(|r| matches!(r.inner, ItemDefinitionInner::Constant(_)))
+                });
+                // Add blank line between fields and constants
+                if nested_had_fields && nested_has_consts {
+                    writeln!(body)?;
+                }
+                for nested_nested_path in &nested_td.nested_item_paths {
+                    if let Ok(nested_nested_item) = ctx
+                        .registry
+                        .get(nested_nested_path, &ItemLocation::internal())
+                        && let Some(nested_nested_resolved) = nested_nested_item.resolved()
+                        && let ItemDefinitionInner::Constant(nested_cd) =
+                            &nested_nested_resolved.inner
+                    {
+                        let nested_const_name = nested_nested_path
+                            .last()
+                            .map(|s| s.as_str().to_string())
+                            .unwrap_or_default();
+                        let nested_const_name = super::cpp_ident(&nested_const_name);
+                        super::types::render_doc(
+                            body,
+                            &nested_cd.doc,
+                            2,
+                            ctx,
+                            &nested_nested_item.location,
+                        )?;
+                        let bf_type = super::render_type(&nested_cd.type_, ctx)?;
+                        let value_str = format_const_value(&nested_cd.value, &nested_cd.type_);
+                        writeln!(
+                            body,
+                            "        static constexpr {bf_type} {nested_const_name} = {value_str};"
+                        )?;
+                    }
+                }
+                writeln!(body, "    }};")?;
+            }
+            ItemDefinitionInner::Union(nested_ud) => {
+                super::types::render_doc(body, &nested_ud.doc, 1, ctx, &nested_item.location)?;
+                writeln!(body, "    union {nested_name} {{")?;
+                for region in &nested_ud.regions {
+                    super::items::render_field_indented(body, region, ctx, false, 2)?;
+                }
+                writeln!(body, "    }};")?;
+            }
+            ItemDefinitionInner::Enum(nested_ed) => {
+                super::types::render_doc(body, &nested_ed.doc, 1, ctx, &nested_item.location)?;
+                writeln!(
+                    body,
+                    "    enum class {nested_name} : {} {{",
+                    super::render_type(&nested_ed.type_, ctx)?
+                )?;
+                for variant in &nested_ed.variants {
+                    writeln!(
+                        body,
+                        "        {} = {},",
+                        super::cpp_ident(&variant.name),
+                        variant.value
+                    )?;
+                }
+                writeln!(body, "    }};")?;
+            }
+            ItemDefinitionInner::Bitflags(nested_bd) => {
+                super::types::render_doc(body, &nested_bd.doc, 1, ctx, &nested_item.location)?;
+                writeln!(body, "    struct {nested_name} {{")?;
+                let bf_type = super::render_type(&nested_bd.type_, ctx)?;
+                for flag in &nested_bd.flags {
+                    writeln!(
+                        body,
+                        "        static constexpr {bf_type} {} = {};",
+                        super::cpp_ident(&flag.name),
+                        flag.value
+                    )?;
+                }
+                writeln!(body, "    }};")?;
+            }
+            ItemDefinitionInner::TypeAlias(nested_ta) => {
+                super::types::render_doc(body, &nested_ta.doc, 1, ctx, &nested_item.location)?;
+                writeln!(
+                    body,
+                    "    using {nested_name} = {};",
+                    super::render_type(&nested_ta.target, ctx)?
+                )?;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Render value-declaring nested items (constants and extern values) inside
+/// the struct body. These come *after* the parent's fields — their in-class
+/// declarations don't name the enclosing type's members at the same field
+/// level, and out-of-class constants need the enclosing type complete anyway.
+/// Constants needing an out-of-class definition are pushed into
+/// `deferred_consts`.
+pub(super) fn render_value_declarations(
     body: &mut String,
     nested_item_paths: &[ItemPath],
     ctx: RenderCtx,
     deferred_consts: &mut Vec<(String, String, String)>,
 ) -> Result<()> {
-    if nested_item_paths.is_empty() {
-        return Ok(());
-    }
     let mut prev_was_constant = false;
     for nested_path in nested_item_paths {
-        if let Ok(nested_item) = ctx.registry.get(nested_path, &ItemLocation::internal()) {
-            if let Some(nested_resolved) = nested_item.resolved() {
-                let curr_is_constant =
-                    matches!(&nested_resolved.inner, ItemDefinitionInner::Constant(_));
-                // Add blank line before nested item if body has content,
-                // unless both the previous and current items are constants
-                // (consecutive constants form a contiguous block).
-                if !body.trim().is_empty() && !(prev_was_constant && curr_is_constant) {
-                    writeln!(body)?;
-                }
-                prev_was_constant = curr_is_constant;
-                let nested_name = nested_path
-                    .last()
-                    .map(|s| s.as_str().to_string())
-                    .unwrap_or_default();
-                let nested_name = super::cpp_ident(&nested_name);
-                match &nested_resolved.inner {
-                    ItemDefinitionInner::Type(nested_td) => {
-                        super::types::render_doc(
-                            body,
-                            &nested_td.doc,
-                            1,
-                            ctx,
-                            &nested_item.location,
-                        )?;
-                        writeln!(body, "    struct {nested_name} {{")?;
-                        let nested_had_fields = !nested_td.regions.is_empty();
-                        for region in &nested_td.regions {
-                            super::items::render_field_indented(body, region, ctx, false, 2)?;
-                        }
-                        // Render nested constants inside the nested struct
-                        let nested_has_consts = nested_td.nested_item_paths.iter().any(|p| {
-                            ctx.registry
-                                .get(p, &ItemLocation::internal())
-                                .ok()
-                                .and_then(|i| i.resolved())
-                                .is_some_and(|r| {
-                                    matches!(r.inner, ItemDefinitionInner::Constant(_))
-                                })
-                        });
-                        // Add blank line between fields and constants
-                        if nested_had_fields && nested_has_consts {
-                            writeln!(body)?;
-                        }
-                        for nested_nested_path in &nested_td.nested_item_paths {
-                            if let Ok(nested_nested_item) = ctx
-                                .registry
-                                .get(nested_nested_path, &ItemLocation::internal())
-                                && let Some(nested_nested_resolved) = nested_nested_item.resolved()
-                                && let ItemDefinitionInner::Constant(nested_cd) =
-                                    &nested_nested_resolved.inner
-                            {
-                                let nested_const_name = nested_nested_path
-                                    .last()
-                                    .map(|s| s.as_str().to_string())
-                                    .unwrap_or_default();
-                                let nested_const_name = super::cpp_ident(&nested_const_name);
-                                super::types::render_doc(
-                                    body,
-                                    &nested_cd.doc,
-                                    2,
-                                    ctx,
-                                    &nested_nested_item.location,
-                                )?;
-                                let bf_type = super::render_type(&nested_cd.type_, ctx)?;
-                                let value_str =
-                                    format_const_value(&nested_cd.value, &nested_cd.type_);
-                                writeln!(
-                                    body,
-                                    "        static constexpr {bf_type} {nested_const_name} = {value_str};"
-                                )?;
-                            }
-                        }
-                        writeln!(body, "    }};")?;
-                    }
-                    ItemDefinitionInner::Union(nested_ud) => {
-                        super::types::render_doc(
-                            body,
-                            &nested_ud.doc,
-                            1,
-                            ctx,
-                            &nested_item.location,
-                        )?;
-                        writeln!(body, "    union {nested_name} {{")?;
-                        for region in &nested_ud.regions {
-                            super::items::render_field_indented(body, region, ctx, false, 2)?;
-                        }
-                        writeln!(body, "    }};")?;
-                    }
-                    ItemDefinitionInner::Enum(nested_ed) => {
-                        super::types::render_doc(
-                            body,
-                            &nested_ed.doc,
-                            1,
-                            ctx,
-                            &nested_item.location,
-                        )?;
-                        writeln!(
-                            body,
-                            "    enum class {nested_name} : {} {{",
-                            super::render_type(&nested_ed.type_, ctx)?
-                        )?;
-                        for variant in &nested_ed.variants {
-                            writeln!(
-                                body,
-                                "        {} = {},",
-                                super::cpp_ident(&variant.name),
-                                variant.value
-                            )?;
-                        }
-                        writeln!(body, "    }};")?;
-                    }
-                    ItemDefinitionInner::Bitflags(nested_bd) => {
-                        super::types::render_doc(
-                            body,
-                            &nested_bd.doc,
-                            1,
-                            ctx,
-                            &nested_item.location,
-                        )?;
-                        writeln!(body, "    struct {nested_name} {{")?;
-                        let bf_type = super::render_type(&nested_bd.type_, ctx)?;
-                        for flag in &nested_bd.flags {
-                            writeln!(
-                                body,
-                                "        static constexpr {bf_type} {} = {};",
-                                super::cpp_ident(&flag.name),
-                                flag.value
-                            )?;
-                        }
-                        writeln!(body, "    }};")?;
-                    }
-                    ItemDefinitionInner::TypeAlias(nested_ta) => {
-                        super::types::render_doc(
-                            body,
-                            &nested_ta.doc,
-                            1,
-                            ctx,
-                            &nested_item.location,
-                        )?;
-                        writeln!(
-                            body,
-                            "    using {nested_name} = {};",
-                            super::render_type(&nested_ta.target, ctx)?
-                        )?;
-                    }
-                    ItemDefinitionInner::Constant(nested_cd) => {
-                        super::types::render_doc(
-                            body,
-                            &nested_cd.doc,
-                            1,
-                            ctx,
-                            &nested_item.location,
-                        )?;
-                        let bf_type = super::render_type(&nested_cd.type_, ctx)?;
-                        let value_str = format_const_value(&nested_cd.value, &nested_cd.type_);
-                        // For scalar/POD types, use `static constexpr` with
-                        // in-class initialization. For struct/array/const-ref
-                        // types, the type may not be a C++ literal type (trivial
-                        // ctor/dtor), and if the type is the enclosing class
-                        // itself, it's incomplete inside the body. So declare
-                        // `static const T name;` here (no initializer) and
-                        // define `inline const T Class::name = ...;` after
-                        // the class body (in `post_header`).
-                        let needs_out_of_class = matches!(
-                            &nested_cd.value,
-                            ConstValue::Struct { .. }
-                                | ConstValue::Array(_)
-                                | ConstValue::ConstRef(_)
-                        );
-                        if needs_out_of_class {
-                            writeln!(body, "    static const {bf_type} {nested_name};")?;
-                            deferred_consts.push((nested_name.to_string(), bf_type, value_str));
-                        } else {
-                            writeln!(
-                                body,
-                                "    static constexpr {bf_type} {nested_name} = {value_str};"
-                            )?;
-                        }
-                    }
-                    ItemDefinitionInner::ExternValue(nested_ev) => {
-                        // A nested extern value (e.g. a C++ class's static
-                        // global) becomes a static accessor over its address.
-                        // Declared here; defined out-of-class below (in the
-                        // `.cpp` for non-templates, like the singleton
-                        // accessor and member functions).
-                        super::types::render_doc(
-                            body,
-                            &nested_ev.doc,
-                            1,
-                            ctx,
-                            &nested_item.location,
-                        )?;
-                        let decl = super::render_declaration(
-                            &nested_ev.type_,
-                            &format!("&get_{nested_name}()"),
-                            ctx,
-                        )?;
-                        writeln!(body, "    static {decl};")?;
-                    }
+        let Ok(nested_item) = ctx.registry.get(nested_path, &ItemLocation::internal()) else {
+            continue;
+        };
+        let Some(nested_resolved) = nested_item.resolved() else {
+            continue;
+        };
+        if !matches!(
+            &nested_resolved.inner,
+            ItemDefinitionInner::Constant(_) | ItemDefinitionInner::ExternValue(_)
+        ) {
+            continue;
+        }
+        let curr_is_constant = matches!(&nested_resolved.inner, ItemDefinitionInner::Constant(_));
+        // Add blank line before nested item if body has content,
+        // unless both the previous and current items are constants
+        // (consecutive constants form a contiguous block).
+        if !body.trim().is_empty() && !(prev_was_constant && curr_is_constant) {
+            writeln!(body)?;
+        }
+        prev_was_constant = curr_is_constant;
+        let nested_name = nested_path
+            .last()
+            .map(|s| s.as_str().to_string())
+            .unwrap_or_default();
+        let nested_name = super::cpp_ident(&nested_name);
+        match &nested_resolved.inner {
+            ItemDefinitionInner::Constant(nested_cd) => {
+                super::types::render_doc(body, &nested_cd.doc, 1, ctx, &nested_item.location)?;
+                let bf_type = super::render_type(&nested_cd.type_, ctx)?;
+                let value_str = format_const_value(&nested_cd.value, &nested_cd.type_);
+                // For scalar/POD types, use `static constexpr` with
+                // in-class initialization. For struct/array/const-ref
+                // types, the type may not be a C++ literal type (trivial
+                // ctor/dtor), and if the type is the enclosing class
+                // itself, it's incomplete inside the body. So declare
+                // `static const T name;` here (no initializer) and
+                // define `inline const T Class::name = ...;` after
+                // the class body (in `post_header`).
+                let needs_out_of_class = matches!(
+                    &nested_cd.value,
+                    ConstValue::Struct { .. } | ConstValue::Array(_) | ConstValue::ConstRef(_)
+                );
+                if needs_out_of_class {
+                    writeln!(body, "    static const {bf_type} {nested_name};")?;
+                    deferred_consts.push((nested_name.to_string(), bf_type, value_str));
+                } else {
+                    writeln!(
+                        body,
+                        "    static constexpr {bf_type} {nested_name} = {value_str};"
+                    )?;
                 }
             }
+            ItemDefinitionInner::ExternValue(nested_ev) => {
+                // A nested extern value (e.g. a C++ class's static
+                // global) becomes a static accessor over its address.
+                // Declared here; defined out-of-class below (in the
+                // `.cpp` for non-templates, like the singleton
+                // accessor and member functions).
+                super::types::render_doc(body, &nested_ev.doc, 1, ctx, &nested_item.location)?;
+                let decl = super::render_declaration(
+                    &nested_ev.type_,
+                    &format!("&get_{nested_name}()"),
+                    ctx,
+                )?;
+                writeln!(body, "    static {decl};")?;
+            }
+            _ => {}
         }
     }
     Ok(())

--- a/src/backends/cpp/render/structs.rs
+++ b/src/backends/cpp/render/structs.rs
@@ -68,6 +68,13 @@ pub(super) fn render_struct(
     // system without inheritance is awkward, so we use `void*` as the
     // ABI-compatible escape hatch.
     let is_vftable_struct = name.ends_with("Vftable");
+
+    // Type-declaring nested items (types, unions, enums, bitflags, aliases)
+    // come before the fields so a field inside this struct may reference one
+    // (`Outer::Inner`). Value items (constants, extern values) are emitted
+    // after the fields.
+    super::nested::render_type_declarations(&mut body, &td.nested_item_paths, ctx)?;
+
     for region in &td.regions {
         super::items::render_field(&mut body, region, ctx, is_vftable_struct)?;
     }
@@ -76,13 +83,13 @@ pub(super) fn render_struct(
     render_singleton_declaration(&mut body, name, td)?;
     render_vftable_declarations(&mut body, td, ctx)?;
     render_associated_function_declarations(&mut body, td, ctx)?;
-    render_deleted_special_members(&mut body, name, td)?;
-    super::nested::render_declarations(
+    super::nested::render_value_declarations(
         &mut body,
         &td.nested_item_paths,
         ctx,
         &mut deferred_consts,
     )?;
+    render_deleted_special_members(&mut body, name, td)?;
 
     if body.trim().is_empty() {
         writeln!(out, "{header} {{}};")?;

--- a/src/backends/cpp/render/unions.rs
+++ b/src/backends/cpp/render/unions.rs
@@ -24,6 +24,10 @@ pub(super) fn render_union(
     }
 
     let mut body = String::new();
+
+    // Type-declaring nested items come before fields so a member may reference
+    // one (`Outer::Inner`).
+    super::nested::render_type_declarations(&mut body, &ud.nested_item_paths, ctx)?;
     for region in &ud.regions {
         super::items::render_field(&mut body, region, ctx, false)?;
     }
@@ -34,7 +38,7 @@ pub(super) fn render_union(
     // identically.
     let mut deferred_consts: Vec<(String, String, String)> = Vec::new();
     super::structs::render_deleted_special_members_if(&mut body, name, ud.pinned)?;
-    super::nested::render_declarations(
+    super::nested::render_value_declarations(
         &mut body,
         &ud.nested_item_paths,
         ctx,

--- a/src/parser/paths.rs
+++ b/src/parser/paths.rs
@@ -104,6 +104,14 @@ impl ItemPath {
         self.0.last()
     }
 
+    /// Clone `self` and append every segment of `path` onto it. Used to resolve
+    /// a qualified path relative to a scope base: `base.join_path(path)`.
+    pub fn join_path(&self, path: &ItemPath) -> ItemPath {
+        let mut out = self.clone();
+        out.0.extend_from_slice(&path.0);
+        out
+    }
+
     /// Check if this path starts with the given prefix.
     /// For example, `a::b::c` starts with `a::b` but not with `a::c`.
     pub fn starts_with(&self, prefix: &ItemPath) -> bool {
@@ -263,6 +271,23 @@ mod path_mapping_tests {
         assert_eq!(
             ItemPath::from_path(Path::new("clock.pyxis")),
             ItemPath::from("clock")
+        );
+    }
+
+    #[test]
+    fn join_path_appends_all_segments() {
+        assert_eq!(
+            ItemPath::from("main").join_path(&ItemPath::from("Outer::Header")),
+            ItemPath::from("main::Outer::Header")
+        );
+        assert_eq!(
+            ItemPath::empty().join_path(&ItemPath::from("Outer::Header")),
+            ItemPath::from("Outer::Header")
+        );
+        // Appending an empty path is a no-op.
+        assert_eq!(
+            ItemPath::from("main").join_path(&ItemPath::empty()),
+            ItemPath::from("main")
         );
     }
 }

--- a/src/semantic/name_index.rs
+++ b/src/semantic/name_index.rs
@@ -500,6 +500,19 @@ impl NameIndex {
                 return Some(canonical);
             }
         }
+        // Relative multi-segment: mirror the type registry — try `base + path`
+        // for each base in empty() ∪ scope, so `Outer::Header` resolves to
+        // `main::Outer::Header` when scope contains `main`.
+        if path.len() > 1 {
+            for base in std::iter::once(&ItemPath::empty()).chain(scope) {
+                let candidate = base.join_path(path);
+                let canonical = self.canonicalize(&candidate);
+                if self.items.contains_key(&canonical) || self.extern_types.contains_key(&canonical)
+                {
+                    return Some(canonical);
+                }
+            }
+        }
         match self.resolve_name(scope, path.last()?.as_str()) {
             NameResolution::Found(p)
             | NameResolution::FoundExtern(p)

--- a/src/semantic/queries/helpers.rs
+++ b/src/semantic/queries/helpers.rs
@@ -348,9 +348,20 @@ fn collect_value_refs(
         TypeKind::Ident {
             path, generic_args, ..
         } => {
-            let name = path.last().map(|s| s.as_str()).unwrap_or("");
-            if let NameResolution::Found(p) = index.resolve_name(scope, name) {
-                refs.push(p);
+            if path.len() > 1 {
+                // A qualified type path: resolve it fully so its owner is
+                // awaited, e.g. `Outer::Header` -> `main::Outer::Header`, or
+                // the module-relative absolute `sub::inner::Header`. Leaf-only
+                // fallback could not find either, which is what stalled the
+                // build.
+                if let Some(p) = index.resolve_path(scope, path) {
+                    refs.push(p);
+                }
+            } else {
+                let name = path.last().map(|s| s.as_str()).unwrap_or("");
+                if let NameResolution::Found(p) = index.resolve_name(scope, name) {
+                    refs.push(p);
+                }
             }
             // Generic arguments of a value type are treated as value deps too
             // (conservative — resolving an extra one is harmless; missing one

--- a/src/semantic/tests/mod.rs
+++ b/src/semantic/tests/mod.rs
@@ -39,6 +39,7 @@ mod imports;
 mod inheritance;
 mod min_size;
 mod modules;
+mod nested_items;
 mod pinned;
 mod queries;
 mod type_aliases;

--- a/src/semantic/tests/nested_items.rs
+++ b/src/semantic/tests/nested_items.rs
@@ -1,0 +1,294 @@
+//! Tests for resolving qualified references to nested items in type position.
+//!
+//! A nested item is always spelled with its parent (`Outer::Inner`); a bare
+//! `Inner` inside `Outer` does not resolve. Both halves of that contract are
+//! exercised here.
+
+use crate::{
+    grammar::test_aliases::*,
+    semantic::{
+        builder::SemanticBuilder,
+        error::{SemanticError, UnresolvedTypeContext, UnresolvedTypeReference},
+        types::test_aliases::*,
+    },
+    span::{ItemLocation, StripLocations},
+};
+
+use super::util::*;
+
+/// A nested item referenced by its qualified name inside the parent's own body
+/// resolves: `Outer::Header` -> `test::Outer::Header`.
+#[test]
+fn nested_qualified_field_resolves() {
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "Outer"),
+            TD::new([
+                TS::item(ID::new(
+                    (V::Public, "Header"),
+                    TD::new([TS::field((V::Public, "magic"), T::ident("u32"))]),
+                )),
+                TS::field((V::Public, "header"), T::ident("Outer::Header")),
+            ]),
+        )]),
+        [
+            SID::defined_resolved(
+                (SV::Public, "test::Outer"),
+                SISR::new(
+                    (4, 4),
+                    STD::new()
+                        .with_regions([SR::field(
+                            (SV::Public, "header"),
+                            ST::raw("test::Outer::Header"),
+                        )])
+                        .with_nested_item_paths([IP::from("test::Outer::Header")]),
+                ),
+            ),
+            SID::defined_resolved(
+                (SV::Public, "test::Outer::Header"),
+                SISR::new(
+                    (4, 4),
+                    STD::new().with_regions([SR::field((SV::Public, "magic"), ST::raw("u32"))]),
+                ),
+            ),
+        ],
+    );
+}
+
+/// A nested `enum` referenced by its qualified name resolves.
+#[test]
+fn nested_qualified_enum_resolves() {
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "Outer"),
+            TD::new([
+                TS::item(ID::new(
+                    (V::Public, "InnerEnum"),
+                    ED::new(T::ident("u8"), [ES::field("A"), ES::field("B")], []),
+                )),
+                TS::field((V::Public, "tag"), T::ident("Outer::InnerEnum")),
+            ]),
+        )]),
+        [
+            SID::defined_resolved(
+                (SV::Public, "test::Outer"),
+                SISR::new(
+                    (1, 1),
+                    STD::new()
+                        .with_regions([SR::field(
+                            (SV::Public, "tag"),
+                            ST::raw("test::Outer::InnerEnum"),
+                        )])
+                        .with_nested_item_paths([IP::from("test::Outer::InnerEnum")]),
+                ),
+            ),
+            SID::defined_resolved(
+                (SV::Public, "test::Outer::InnerEnum"),
+                SISR::new(
+                    (1, 1),
+                    SED::new(ST::raw("u8")).with_variants([("A", 0), ("B", 1)]),
+                ),
+            ),
+        ],
+    );
+}
+
+/// A nested `bitflags` referenced by its qualified name resolves.
+#[test]
+fn nested_qualified_bitflags_resolves() {
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "Outer"),
+            TD::new([
+                TS::item(ID::new(
+                    (V::Public, "Flags"),
+                    BFD::new(T::ident("u32"), [BFS::field("A", int_literal(1))], []),
+                )),
+                TS::field((V::Public, "flags"), T::ident("Outer::Flags")),
+            ]),
+        )]),
+        [
+            SID::defined_resolved(
+                (SV::Public, "test::Outer"),
+                SISR::new(
+                    (4, 4),
+                    STD::new()
+                        .with_regions([SR::field(
+                            (SV::Public, "flags"),
+                            ST::raw("test::Outer::Flags"),
+                        )])
+                        .with_nested_item_paths([IP::from("test::Outer::Flags")]),
+                ),
+            ),
+            SID::defined_resolved(
+                (SV::Public, "test::Outer::Flags"),
+                SISR::new((4, 4), SBFD::new(ST::raw("u32")).with_flags([("A", 1)])),
+            ),
+        ],
+    );
+}
+
+/// A nested type alias referenced by its qualified name resolves (and expands).
+#[test]
+fn nested_qualified_type_alias_resolves() {
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "Outer"),
+            TD::new([
+                TS::item(ID::new(
+                    (V::Public, "InnerAlias"),
+                    TAD::new(T::ident("u16")),
+                )),
+                TS::field((V::Public, "alias"), T::ident("Outer::InnerAlias")),
+            ]),
+        )]),
+        [
+            SID::defined_resolved(
+                (SV::Public, "test::Outer"),
+                SISR::new(
+                    (2, 2),
+                    STD::new()
+                        .with_regions([SR::field((SV::Public, "alias"), ST::raw("u16"))])
+                        .with_nested_item_paths([IP::from("test::Outer::InnerAlias")]),
+                ),
+            ),
+            SID::defined_resolved(
+                (SV::Public, "test::Outer::InnerAlias"),
+                SISR::new((0, 1), STAD::new(ST::raw("u16"), vec![])),
+            ),
+        ],
+    );
+}
+
+/// A nested item referenced by its qualified name inside a `union` body resolves.
+#[test]
+fn nested_qualified_union_member_resolves() {
+    assert_ast_produces_type_definitions(
+        M::new().with_definitions([ID::new(
+            (V::Public, "Outer"),
+            UD::new([
+                TS::item(ID::new(
+                    (V::Public, "Header"),
+                    TD::new([TS::field((V::Public, "magic"), T::ident("u32"))]),
+                )),
+                TS::field((V::Public, "header"), T::ident("Outer::Header")),
+                TS::field((V::Public, "raw"), T::ident("u32")),
+            ]),
+        )]),
+        [
+            SID::defined_resolved(
+                (SV::Public, "test::Outer"),
+                SISR::new(
+                    (4, 4),
+                    SUD::new()
+                        .with_regions([
+                            SR::field((SV::Public, "header"), ST::raw("test::Outer::Header")),
+                            SR::field((SV::Public, "raw"), ST::raw("u32")),
+                        ])
+                        .with_nested_item_paths([IP::from("test::Outer::Header")]),
+                ),
+            ),
+            SID::defined_resolved(
+                (SV::Public, "test::Outer::Header"),
+                SISR::new(
+                    (4, 4),
+                    STD::new().with_regions([SR::field((SV::Public, "magic"), ST::raw("u32"))]),
+                ),
+            ),
+        ],
+    );
+}
+
+/// A missing multi-segment path reports the full written path, not just the leaf.
+#[test]
+fn missing_multisegment_path_reports_full_path() {
+    assert_ast_produces_exact_error(
+        M::new().with_definitions([ID::new(
+            (V::Public, "Outer"),
+            TD::new([
+                TS::item(ID::new(
+                    (V::Public, "Header"),
+                    TD::new([TS::field((V::Public, "magic"), T::ident("u32"))]),
+                )),
+                TS::field((V::Public, "missing"), T::ident("Outer::Missing")),
+            ]),
+        )]),
+        SemanticError::TypeResolutionStalled {
+            unresolved_types: vec!["test::Outer".to_string()],
+            resolved_types: vec![],
+            unresolved_references: vec![UnresolvedTypeReference {
+                type_name: "Outer::Missing".to_string(),
+                location: ItemLocation::test(),
+                context: UnresolvedTypeContext::StructField {
+                    field_name: "missing".to_string(),
+                    type_path: IP::from("test::Outer"),
+                },
+            }],
+        },
+    );
+}
+
+/// A module-relative multi-segment path resolves inline: in a `main` module,
+/// `sub::inner::Header` (where `sub::inner` defines `Header`) resolves without
+/// stalling.
+#[test]
+fn module_relative_multisegment_type_resolves() {
+    let main = M::new().with_definitions([ID::new(
+        (V::Public, "User"),
+        TD::new([TS::field((V::Public, "h"), T::ident("sub::inner::Header"))]),
+    )]);
+    let inner = M::new().with_definitions([ID::new(
+        (V::Public, "Header"),
+        TD::new([TS::field((V::Public, "magic"), T::ident("u32"))]),
+    )]);
+
+    let mut builder = SemanticBuilder::new(pointer_size());
+    builder.add_module(&main, &IP::from("main")).unwrap();
+    builder.add_module(&inner, &IP::from("sub::inner")).unwrap();
+    let resolved = builder.build().unwrap();
+
+    let resolved_type = resolved
+        .type_registry()
+        .get(&IP::from("main::User"), &ItemLocation::test())
+        .cloned()
+        .expect("failed to get type");
+    let state = resolved_type.resolved().expect("should resolve");
+    assert_eq!(
+        state.strip_locations(),
+        SISR::new(
+            (4, 4),
+            STD::new().with_regions([SR::field((SV::Public, "h"), ST::raw("sub::inner::Header"))]),
+        )
+        .strip_locations()
+    );
+}
+
+/// A bare nested reference (unqualified) still fails: a nested item is always
+/// spelled with its parent.
+#[test]
+fn bare_nested_reference_still_errors() {
+    assert_ast_produces_exact_error(
+        M::new().with_definitions([ID::new(
+            (V::Public, "Outer"),
+            TD::new([
+                TS::item(ID::new(
+                    (V::Public, "Header"),
+                    TD::new([TS::field((V::Public, "magic"), T::ident("u32"))]),
+                )),
+                TS::field((V::Public, "header"), T::ident("Header")),
+            ]),
+        )]),
+        SemanticError::TypeResolutionStalled {
+            unresolved_types: vec!["test::Outer".to_string()],
+            resolved_types: vec![],
+            unresolved_references: vec![UnresolvedTypeReference {
+                type_name: "Header".to_string(),
+                location: ItemLocation::test(),
+                context: UnresolvedTypeContext::StructField {
+                    field_name: "header".to_string(),
+                    type_path: IP::from("test::Outer"),
+                },
+            }],
+        },
+    );
+}

--- a/src/semantic/type_registry/generics.rs
+++ b/src/semantic/type_registry/generics.rs
@@ -146,8 +146,40 @@ impl TypeRegistry {
             }
         }
 
-        // For single-segment paths or unresolved multi-segment paths,
-        // try scope-based resolution using the last segment
+        // Relative multi-segment: mirror doc_links/resolver.rs — try `base + path`
+        // for each base in empty() ∪ scope, so `Outer::Header` resolves to
+        // `main::Outer::Header` when scope contains `main`.
+        if path.len() > 1 {
+            for base in std::iter::once(&ItemPath::empty()).chain(scope) {
+                let candidate = base.join_path(path);
+                let canonical = self.canonicalize(&candidate);
+                if let Some(item_def) = self.lookup(&canonical) {
+                    // Check visibility for paths resolved through the scope.
+                    if let Some(from) = from_module {
+                        if !self.can_access(from, &canonical) {
+                            return TypeLookupResult::PrivateAccess {
+                                item_path: canonical,
+                            };
+                        }
+                    }
+                    return if item_def.is_resolved() {
+                        TypeLookupResult::Found(self.resolve_type_alias(Type::Raw(canonical)))
+                    } else {
+                        TypeLookupResult::NotYetResolved
+                    };
+                }
+            }
+        }
+
+        // A multi-segment path that matched nothing absolute or relative is a
+        // genuine miss: report the full written path, not just the leaf.
+        if path.len() > 1 {
+            return TypeLookupResult::NotFound {
+                type_name: path.to_string(),
+            };
+        }
+
+        // For single-segment paths, try scope-based resolution using the leaf.
         if let Some(last_segment) = path.last() {
             self.resolve_string(scope, last_segment.as_str())
         } else {


### PR DESCRIPTION
Closes #125

Qualified type paths such as `Outer::Header` (a nested item referenced from inside `Outer`'s own body) or `sub::inner::Header` (module-relative) previously either reported a misleading leaf-only `NotFound` or stalled with "type resolution will not terminate".

## Fix
- `TypeRegistry::resolve_path` / `NameIndex::resolve_path` now scan `empty() ∪ scope` bases prefixed onto the path (mirroring the doc-links resolver), so relative multi-segment paths resolve inline; a miss reports the full written path.
- `collect_value_refs` resolves qualified `Ident` paths through the index so the owner is awaited — the stall is gone.
- `ItemPath::join_path` shares the base-join between both resolves.
- **C++ backend:** nested type declarations now emit before the parent's fields (value items after), so a field can reference a nested type by name; plus a same-module guard in the dep walker to avoid a bogus `#include` self-include. (Operator-directed.)
- Semantic tests for qualified/relative/bare-nested cases, extended codegen corpus (same-body qualified nested references), docs update.

## Verification
- `python test.py` green (clippy, nightly fmt, unit, corpus across all backends, doc build).
- `pyxis-defs` Rust + C++ build checks both pass (JustCause2/3, MadMax).
- Two independent reviews (general-purpose + nat-code-reviewer): no critical/high/medium findings.

## Notes / follow-ups (out of scope)
- Relative resolution for indirect targets (`*Outer::Header` pointees).
- Cross-module nested refs through a `use`'d outer module (`use main::Outer` then `Outer::Header`).